### PR TITLE
Rename to `spago`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .stack-work/
-spacchetti-cli.cabal
+*.cabal
 *~

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,254 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+        spaces: 2
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 100
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: lf
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+language_extensions:
+  - BangPatterns
+  - ConstraintKinds
+  - DataKinds
+  - DeriveDataTypeable
+  - DeriveFunctor
+  - DeriveGeneric
+  - DeriveTraversable
+  - DerivingStrategies
+  - EmptyDataDecls
+  - ExplicitNamespaces
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - OverloadedLabels
+  - OverloadedStrings
+  - PolyKinds
+  - QuasiQuotes
+  - RankNTypes
+  - RecordWildCards
+  - ScopedTypeVariables
+  - TupleSections
+  - TemplateHaskell
+  - TypeApplications
+  - TypeFamilies
+  - TypeInType
+  - TypeOperators
+  - ViewPatterns

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,3 @@
-# Changelog for spacchetti-cli
+# Changelog for spago
 
 ## Unreleased changes

--- a/README.md
+++ b/README.md
@@ -4,10 +4,29 @@
 
 *(IPA: /ˈspaɡo/)*
 
-<img src="https://raw.githubusercontent.com/spacchetti/logo/master/spacchetti-icon.png" height="300px" alt="spacchetti logo">
-
 PureScript package manager and build tool powered by [Dhall][dhall] and
 [Spacchetti][spacchetti] package-sets.
+
+
+<img src="https://raw.githubusercontent.com/spacchetti/logo/master/spacchetti-icon.png" height="300px" alt="spacchetti logo">
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [What does all of this mean?](#what-does-all-of-this-mean)
+- [Installation](#installation)
+- [Quickstart](#quickstart)
+  - [Configuration file format](#configuration-file-format)
+- [Commands](#commands)
+  - [Package management](#package-management)
+  - [Building, bundling and testing a project](#building-bundling-and-testing-a-project)
+- [Can I use this with `psc-package`?](#can-i-use-this-with-psc-package)
+  - [`psc-package-local-setup`](#psc-package-local-setup)
+  - [`psc-package-insdhall`](#psc-package-insdhall)
+- [FAQ](#faq)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## What does all of this mean?
 
@@ -130,7 +149,7 @@ $ spago install
 ..then `spago` will download all the `dependencies` listed in `spago.dhall` (and
 store them in the `.spago` folder).
 
-### Building a project
+### Building, bundling and testing a project
 
 We can then build the project and its dependencies by running:
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,206 @@
-# spacchetti-cli
+# spago
 
-[![Build Status](https://travis-ci.org/justinwoo/spacchetti-cli.svg?branch=master)](https://travis-ci.org/justinwoo/spacchetti-cli)
+[![Build Status](https://travis-ci.org/spacchetti/spago.svg?branch=master)][travis-spago]
 
-**Attention: See the Spacchetti docs first at <https://spacchetti.readthedocs.io/>**
+*(IPA: /ˈspaɡo/)*
 
-A CLI for Spacchetti that does some stuff, but does not do anything that Psc-Package already does.
+<img src="https://raw.githubusercontent.com/spacchetti/logo/master/spacchetti-icon.png" height="300px" alt="spacchetti logo">
+
+PureScript package manager and build tool powered by [Dhall][dhall] and
+[Spacchetti][spacchetti] package-sets.
+
+## What does all of this mean?
+
+`spago` aims to tie together the UX of developing a PureScript project.  
+In this Pursuit (see what I did there) it is heavily inspired by [Rust's Cargo][cargo]
+and [Haskell's Stack][stack], and builds on top of ideas from existing PureScript
+infrastructure and tooling, as [`psc-package`][psc-package], [`pulp`][pulp] and
+[`purp`][purp].
 
 ## Installation
 
-Use the release archives or use NPM on Linux/OSX: <https://github.com/justinwoo/npm-spacchetti-cli-simple>
+> Right, so how can I get this thing?
 
-## Features
+The recommended installation methods on Linux and macOS are:
+- `npm install -g purescript-spago` (see the latest releases on npm [here][spago-npm])
+- Download the binary from the [latest GitHub release][spago-latest-release]
+- Compile from source by cloning this repo and running `stack install`
 
-### LocalSetup
+**Note #1:** we don't currently support Windows, and we're sorry for this. The
+reason is that no current maintainer runs it. If you'd like to help with this
+that's awesome! Get in touch by [opening an issue][spago-issues] :)
 
-Do the boilerplate of the local project setup to override and add arbitrary packages
-See the Spacchetti docs about this here: <https://spacchetti.readthedocs.io/en/latest/local-setup.html>
+**Note #2:** we assume you already installed the [PureScript compiler][purescript].
+If not, get it with `npm install -g purescript`
 
-### InsDhall
+## Quickstart
 
-Do the Ins-Dhall-ation of the local project setup, equivalent to:
+Let's set up a new project!
+
+```bash
+$ mkdir purescript-unicorns
+$ cd purescript-unicorns
+$ spago init
+```
+
+This last command will create a bunch of files:
+
+```
+.
+├── packages.dhall
+├── spago.dhall
+├── src
+│   └── Main.purs
+└── test
+    └── Main.purs
+```
+
+Convention note: `spago` expects your source files to be in `src/` and your
+test files in `test/`.
+
+Let's take a look at the two [Dhall][dhall] configuration files that `spago` requires:
+- `packages.dhall`: this file is meant to contain the *totality* of the packages
+  available to your project (that is, any package you might want to import).  
+  In practical terms, it pulls in a [Spacchetti][spacchetti] package-set as a base,
+  and you are then able to add any package that might not be in the package set,
+  or override esisting ones.
+- `spago.dhall`: this is your project configuration. It includes the above package-set,
+  the list of your dependencies, and any other project-wide setting that `spago` will 
+  use for builds.
+
+### Configuration file format
+
+It's indeed useful to know what's the format (or more precisely, the [Dhall][dhall]
+type) of the files that `spago` expects. Let's define them in Dhall:
+
+```haskell
+-- The basic building block is a Package:
+let Package =
+  { dependencies : List Text  -- the list of dependencies of the Package
+  , repo = Text               -- the address of the git repo the Package is at
+  , version = Text            -- git tag
+  }
+
+-- The type of `packages.dhall` is a Record from a PackageName to a Package
+-- We're kind of stretching Dhall syntax here when defining this, but let's
+-- say that its type is something like this:
+let Packages =
+  { console : Package
+  , effect : Package
+  ...                  -- and so on, for all the packages in the package-set
+  }
+
+-- The type of the `spago.dhall` configuration is then the following:
+let Config =
+  { name : Text               -- the name of our project
+  , dependencies : List Text  -- the list of dependencies of our app
+  , packages : Packages       -- this is the type we just defined above
+  }
+```
+
+## Commands
+
+For an overview of the available commands, run:
+
+```bash
+$ spago --help
+```
+
+You will see several subcommands (e.g. `build`, `test`); you can ask for help
+about them by invoking the command with `--help`, e.g.:
+
+```bash
+$ spago build --help
+```
+
+This will give a detailed view of the command, and list any command-specific
+(vs global) flags.
+
+### Package management
+
+We initialized a project and saw how to configure dependencies and packages, the
+next step is fetching its dependencies.
+
+If we run:
+
+```bash
+$ spago install
+```
+
+..then `spago` will download all the `dependencies` listed in `spago.dhall` (and
+store them in the `.spago` folder).
+
+### Building a project
+
+We can then build the project and its dependencies by running:
+
+```bash
+$ spago build
+```
+
+This is just a thin layer above the PureScript compiler command `purs compile`.  
+The build will produce very many JavaScript files in the `output/` folder. These
+are CommonJS modules, and you can just `require()` them e.g. on Node.
+
+However, you might want to get a single, executable file. You'd then use the following:
+
+```bash
+# You can specify the main module and the target file, or these defaults will be used
+$ spago bundle --main Main --to index.js
+Bundle succeeded and output file to index.js
+
+# We can then run it with node:
+$ node .
+```
+
+*However*, you might want to build a module that has been “dead code eliminated”
+if you plan to make a single module of your PS exports, which can then be required
+from JS.
+
+Gotcha covered:
+
+```bash
+# You can specify the main module and the target file, or these defaults will be used
+$ spago make-module --main Main --to index.js
+Bundling first...
+Bundle succeeded and output file to index.js
+Make module succeeded and output file to index.js
+
+> node -e "console.log(require('./index).main)"
+[Function]
+```
+
+You can also test your project with `spago`:
+
+```bash
+# Test.Main is the default here, but you can override it as usual
+$ spago test --main Test.Main
+Build succeeded.
+You should add some tests.
+Tests succeeded.
+```
+
+## Can I use this with `psc-package`?
+
+Yes! Though the scope of the integration is limited to helping your
+psc-package-project to use the [Spacchetti][spacchetti] package-set.
+
+Here's what we can do about it:
+
+### `psc-package-local-setup`
+
+This command creates a `packages.dhall` file in your project, that points to the
+most recent Spacchetti package-set, and lets you override and add arbitrary packages.  
+See the Spacchetti docs about this [here][spacchetti-local-setup].
+
+### `psc-package-insdhall`
+
+Do the *Ins-Dhall-ation* of the local project setup: that is, generates a local
+package-set for `psc-package` from your `packages.dhall`, and points your
+`psc-package.json` to it.
+
+Functionally this is equivalent to running:
+
 ```sh
 NAME='local'
 TARGET=.psc-package/$NAME/.set/packages.json
@@ -28,6 +209,42 @@ dhall-to-json --pretty <<< './packages.dhall' > $TARGET
 echo wrote packages.json to $TARGET
 ```
 
-## Example
+## FAQ
 
-See this commit for an example of how this ends up being used: <https://github.com/justinwoo/vidtracker/commit/9887cbbf238ff7fa74b0c47a6cb3b7cc5513327f>
+> Hey wait we have a perfectly functional `pulp` right?
+
+Yees, however:
+- `pulp` is a build tool, so you'll still have to use it with `bower` or `psc-package`.
+- If you go for `bower`, you're missing out on package-sets (that is: packages versions
+  that are known to be working together, saving you the headache of fitting package
+  versions together all the time).
+- If you use `psc-package`, you have the problem of not having the ability of overriding
+  packages versions when needed, leading everyone to make their own package-set, which
+  then goes unmaintained, etc.  
+  Of course you can use [Spacchetti] to solve this issue, but this is exactly what
+  we're doing here: integrating all the workflow in a single tool, `spago`, instead
+  of having to use `pulp`, `psc-package`, `purp`, etc.
+  
+> So if I use `spago make-module` this thing will compile all my js deps in the file?
+
+No. We only take care of PureScript land. In particular, `make-module` will do the
+most we can do on the PureScript side of things (dead code elimination), but will
+leave the `require`s still in.  
+To fill them in you should use the proper js tool of the day, at the time of
+writing [ParcelJS][parcel] looks like a good option.
+
+
+[spacchetti]: https://github.com/spacchetti/spacchetti
+[dhall]: https://github.com/dhall-lang/dhall-lang
+[travis-spago]: https://travis-ci.org/spacchetti/spago
+[spacchetti-local-setup]: https://spacchetti.readthedocs.io/en/latest/local-setup.html
+[cargo]: https://github.com/rust-lang/cargo
+[stack]: https://github.com/commercialhaskell/stack
+[psc-package]: https://github.com/purescript/psc-package
+[pulp]: https://github.com/purescript-contrib/pulp
+[purp]: https://github.com/justinwoo/purp
+[parcel]: https://parceljs.org
+[purescript]: https://github.com/purescript/purescript
+[spago-npm]: https://www.npmjs.com/package/purescript-spago
+[spago-latest-release]: https://github.com/spacchetti/spago/releases/latest
+[spago-issues]: https://github.com/spacchetti/spacchetti-cli/issues

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,376 +1,116 @@
-{-# LANGUAGE DeriveDataTypeable    #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+module Main (main) where
 
-module Main where
-
-import           Control.Exception        (SomeException, throwIO, try)
-import qualified Data.Aeson               as JSON
-import qualified Data.Aeson.Encode.Pretty as JSON
-import qualified Data.ByteString.Lazy     as ByteString.Lazy
-import qualified Data.List                as List
-import qualified Data.Map                 as Map
-import           Data.Text                (Text)
-import qualified Data.Text                as Text
-import qualified Data.Text.Encoding       as Text
-import           Data.Version             (showVersion)
-import qualified Dhall.Format             as Dhall.Format
-import qualified Dhall.JSON               as Dhall.JSON
-import qualified Dhall.Pretty             as Dhall.Pretty
 import qualified GHC.IO.Encoding
-import qualified Paths_spacchetti_cli     as Pcli
+import qualified Turtle          as T
+
 import qualified PscPackage
-import           Spacchetti               (Package, PackageName)
-import qualified Spacchetti
-import qualified System.Directory         as Dir
-import qualified Templates
-import qualified Turtle                   as T
+import qualified Spago
+
 
 -- | Commands that this program handles
 data Command
-  -- | # Commands for working with Psc-Package:
 
-  -- | Do the boilerplate of the local project setup to override and add arbitrary packages
-  -- | See the Spacchetti docs about this here: https://spacchetti.readthedocs.io/en/latest/local-setup.html
-  = LocalSetup Bool
-  -- | Do the Ins-Dhall-ation of the local project setup, equivalent to:
-  -- | ```sh
-  -- | NAME='local'
-  -- | TARGET=.psc-package/$NAME/.set/packages.json
-  -- | mktree -p .psc-package/$NAME/.set
-  -- | dhall-to-json --pretty <<< './packages.dhall' > $TARGET
-  -- | echo wrote packages.json to $TARGET
-  -- | ```
-  | InsDhall
-  -- | Deletes the .psc-package folder
-  | Clean
+  -- | ### Commands for working with Spago projects
+  --
+  -- | Initialize a new project
+  = Init Bool
 
-  -- | # Commands for working with Spacchetti projects
-  -- | Initialize a Spacchetti project
-  | InitSpacchetti Bool
-  -- | Install dependencies defined in spacchetti.dhall
+  -- | Install (download) dependencies defined in spago.dhall
   | Install
-  -- | Get source globs of dependencies in .spacchetti install path
+
+  -- | Get source globs of dependencies in spago.dhall
   | Sources
+
   -- | Build the project paths src/ and test/
   | Build
 
-  -- | Show spacchetti-cli version
+
+  -- | ### Commands for working with Psc-Package
+  --
+  --   Do the boilerplate of the local project setup to override and add arbitrary packages
+  --   See the Spacchetti docs about this here:
+  --   https://spacchetti.readthedocs.io/en/latest/local-setup.html
+  | PscPackageLocalSetup Bool
+
+  -- | Do the Ins-Dhall-ation of the local project setup, equivalent to:
+  --   ```sh
+  --   NAME='local'
+  --   TARGET=.psc-package/$NAME/.set/packages.json
+  --   mktree -p .psc-package/$NAME/.set
+  --   dhall-to-json --pretty <<< './packages.dhall' > $TARGET
+  --   echo wrote packages.json to $TARGET
+  --   ```
+  | PscPackageInsDhall
+
+  -- | Deletes the .psc-package folder
+  | PscPackageClean
+
+
+  -- | Show version
   | Version
-
-
-echo' :: Text -> IO ()
-echo' = T.echo . T.unsafeTextToLine
-
-unsafePathToText :: T.FilePath -> Text
-unsafePathToText p = case T.toText p of
-  Left t  -> t
-  Right t -> t
-
-
--- | The directory in which spacchetti will put its tempfiles
-spacchettiDir :: Text
-spacchettiDir = ".spacchetti/"
-
-pscPackageBasePathText :: Text
-pscPackageBasePathText = ".psc-package/local/.set/"
-
-pscPackageBasePath :: T.FilePath
-pscPackageBasePath = T.fromText pscPackageBasePathText
-
-packagesJsonText :: Text
-packagesJsonText = pscPackageBasePathText <> "packages.json"
-
-packagesJsonPath :: T.FilePath
-packagesJsonPath = T.fromText packagesJsonText
-
-packagesDhallText :: Text
-packagesDhallText = "./packages.dhall"
-
-packagesDhallPath :: T.FilePath
-packagesDhallPath = T.fromText packagesDhallText
-
-spacchettiDhallText :: Text
-spacchettiDhallText = "spacchetti.dhall"
-
-spacchettiDhallPath :: T.FilePath
-spacchettiDhallPath = T.fromText spacchettiDhallText
-
-spacchettiJsonText :: Text
-spacchettiJsonText = spacchettiDir <> "spacchetti.json"
-
-spacchettiJsonPath :: T.FilePath
-spacchettiJsonPath = T.fromText spacchettiJsonText
-
-
-insDhall :: IO ()
-insDhall = do
-  isProject <- T.testfile packagesDhallPath
-  T.unless isProject $
-    T.die "Missing packages.dhall file. Run `spacchetti local-setup` first."
-  T.mktree pscPackageBasePath
-  T.touch packagesJsonPath
-
-  try (dhallToJSON packagesDhallPath packagesJsonPath) >>= \case
-    Right _ -> do
-      T.echo $ T.unsafeTextToLine $ "Wrote packages.json to " <> packagesJsonText
-      T.echo "Now you can run `psc-package install`."
-    Left (err :: SomeException) ->
-      T.die ("Failed to insdhall: " <> Text.pack (show err))
-
--- | Tries to create the `packages.dhall` file. Fails when the file already exists,
--- | unless `--force` has been used.
-makePackagesDhall :: Bool -> Text -> IO ()
-makePackagesDhall force command = do
-  T.unless force $ do
-    hasPackagesDhall <- T.testfile packagesDhallPath
-    T.when hasPackagesDhall $ T.die
-       $ "Found " <> packagesDhallText <> ": there's already a project here. "
-      <> "Run `spacchetti " <> command <> " --force` if you're sure you want to overwrite it."
-  T.touch packagesDhallPath
-  T.writeTextFile packagesDhallPath Templates.packagesDhall
-  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack packagesDhallText)
-
--- | Tries to create the `psc-package.json` file. Existing dependencies are preserved,
--- | unless `--force` has been used.
-makePscPackage :: Bool -> IO ()
-makePscPackage force = do
-  hasPscPackage <- T.testfile pscPackageJsonPath
-  if hasPscPackage && not force
-    then do
-      pscPackage <- T.readTextFile pscPackageJsonPath
-      case JSON.eitherDecodeStrict $ Text.encodeUtf8 pscPackage of
-        Left e -> T.die $ "The existing psc-package.json file is in the wrong format: " <>
-          Text.pack e
-        Right p -> do
-          T.writeTextFile pscPackageJsonPath $
-            Templates.encodePscPackage $ p { PscPackage.set = "local", PscPackage.source = "" }
-          T.echo "An existing psc-package.json file was found and upgraded to use local package sets."
-          T.echo $ "It's possible that some of the existing dependencies are not in the default spacchetti package set."
-
-    else do
-      T.touch pscPackageJsonPath
-      pwd <- T.pwd
-      let projectName = case T.toText $ T.filename pwd of
-            Left _  -> "my-project"
-            Right n -> n
-      T.writeTextFile pscPackageJsonPath $ Templates.pscPackageJson projectName
-
-  where
-    pscPackageJsonPath = T.fromText "psc-package.json"
-
--- | Delete the .psc-package folder
-clean :: IO ()
-clean = do
-  let pscDir = "./.psc-package"
-  hasDir <- T.testdir pscDir
-  if hasDir
-    then do
-      T.rmtree pscDir
-      T.echo "Packages cache was cleaned."
-    else T.echo "Nothing to clean here."
-
-
--- | Copies over `spacchetti.dhall` to set up a Spacchetti project
-makeSpacchetti :: Bool -> IO ()
-makeSpacchetti force = do
-  -- Make sure .spacchetti exists
-  T.mktree $ T.fromText spacchettiDir
-
-  T.unless force $ do
-    hasSpacchettiDhall <- T.testfile spacchettiDhallPath
-    T.when hasSpacchettiDhall $ T.die
-       $ "Found " <> unsafePathToText spacchettiDhallPath <> ": there's already a project here. "
-      <> "Run `spacchetti init --force` if you're sure you want to overwrite it."
-  T.touch spacchettiDhallPath
-  T.writeTextFile spacchettiDhallPath Templates.spacchettiDhall
-
-  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack spacchettiDhallText)
-
-localSetup :: Bool -> IO ()
-localSetup force = do
-  makePackagesDhall force "local-setup"
-  makePscPackage force
-  T.echo "Set up local Spacchetti packages."
-  T.echo "Run `spacchetti insdhall` to generate the package set."
-
-initSpacchetti :: Bool -> IO ()
-initSpacchetti force = do
-  makePackagesDhall force "init"
-  makeSpacchetti force
-  T.mktree "src"
-  T.mktree "test"
-  T.writeTextFile "src/Main.purs" Templates.srcMain
-  T.writeTextFile "test/Main.purs" Templates.testMain
-  T.writeTextFile ".gitignore" Templates.gitignore
-  T.echo "Set up a local Spacchetti project."
-  T.echo "Try running `spacchetti install`"
-
--- | Given a path to a Dhall file and an output path to a JSON file,
---   reads the Dhall, converts it, and writes it as JSON
-dhallToJSON :: T.FilePath -> T.FilePath -> IO ()
-dhallToJSON inputPath outputPath = do
-  let config = JSON.Config
-               { JSON.confIndent = JSON.Spaces 2
-               , JSON.confCompare = compare
-               , JSON.confNumFormat = JSON.Generic
-               , JSON.confTrailingNewline = False }
-
-  dhall <- T.readTextFile inputPath
-
-  json <- Dhall.JSON.codeToValue Dhall.JSON.NoConversion (unsafePathToText inputPath) dhall
-
-  T.writeTextFile outputPath
-    $ Text.decodeUtf8
-    $ ByteString.Lazy.toStrict
-    $ JSON.encodePretty' config json
-
-ensureSpacchettiConfig :: IO Spacchetti.Config
-ensureSpacchettiConfig = do
-  exists <- T.testfile spacchettiDhallPath
-  T.unless exists $ makeSpacchetti False
-  configText <- T.readTextFile spacchettiDhallPath
-  try (Spacchetti.parseConfig configText) >>= \case
-    Right config -> pure config
-    Left (err :: Spacchetti.ConfigReadError) -> throwIO err
-
-install :: IO ()
-install = do
-  config <- ensureSpacchettiConfig
-  let deps = getAllDependencies config
-  echo' $ "Installing " <> Text.pack (show $ List.length deps) <> " dependencies."
-  _ <- traverse getDep deps
-  T.echo "Installation complete."
-
-sources :: IO ()
-sources = do
-  config <- ensureSpacchettiConfig
-  let
-    deps = getAllDependencies config
-    globs = getGlobs deps
-  _ <- traverse (echo') globs
-  pure ()
-
-build :: IO ()
-build = do
-  config <- ensureSpacchettiConfig
-  let
-    deps = getAllDependencies config
-    globs = getGlobs deps <> ["src/**/*.purs", "test/**/*.purs"]
-    paths = Text.intercalate " " $ surroundQuote <$> globs
-    cmd = "purs compile " <> paths
-  code <- T.shell cmd T.empty
-  case code of
-    T.ExitSuccess -> T.echo "Build succeeded."
-    T.ExitFailure n -> do
-      T.die ("Failed to build:" <> T.repr n)
-
--- | Returns the dir path for a given package
-getDir :: (PackageName, Package) -> Text
-getDir (Spacchetti.PackageName{..}, Spacchetti.Package{..})
-  = spacchettiDir <> packageName <> "/" <> version
-
-getGlobs :: [(PackageName, Package)] -> [Text]
-getGlobs = map (\pair -> getDir pair <> "/src/**/*.purs")
-
-getDep :: (PackageName, Package) -> IO ()
-getDep pair@(Spacchetti.PackageName{..}, Spacchetti.Package{..} ) = do
-  let dir = getDir pair
-  exists <- T.testdir $ T.fromText dir
-  if exists
-    then do
-      echo' $ surroundQuote packageName <> " already installed."
-    else do
-      echo' $ "Installing " <> surroundQuote packageName
-      T.mktree . T.fromText $ dir
-      Dir.withCurrentDirectory (Text.unpack dir) $ do
-        let
-          cmd = Text.intercalate " && "
-            [ "git init"
-            , "git remote add origin " <> repo
-            , "git fetch origin " <> version
-            , "git -c advice.detachedHead=false checkout FETCH_HEAD"
-            ]
-        -- Swallow stdout here, we don't want the whole git output.
-        -- stderr is still piped though, so we should get errors
-        try (T.sh $ T.inshell cmd T.empty) >>= \case
-          Right _ -> pure ()
-          Left (err :: T.ExitCode) -> do
-            T.rmtree $ T.fromText dir
-            T.die ("Failed to install dependency: " <> T.repr err)
-
-
-getAllDependencies :: Spacchetti.Config -> [(PackageName, Package)]
-getAllDependencies Spacchetti.Config { dependencies = deps, packages = pkgs } =
-  Map.toList $ List.foldl' go Map.empty deps
-  where
-    go acc dep
-      | Map.member dep acc = acc
-      | otherwise =
-          case Map.lookup dep pkgs of
-            -- lazy error handling, user gets crash
-            Nothing -> error $ "Package " <> show dep <> " was missing from the package set."
-            Just x@(Spacchetti.Package { dependencies = innerDeps }) -> do
-              let newAcc = List.foldl' go acc innerDeps
-              Map.insert dep x newAcc
-
-surroundQuote :: Text -> Text
-surroundQuote y = "\"" <> y <> "\""
-
-printVersion :: IO ()
-printVersion =
-  T.echo $ T.unsafeTextToLine (Text.pack $ showVersion Pcli.version)
 
 
 parser :: T.Parser Command
 parser
-      = LocalSetup <$> localSetup'
-  T.<|> InsDhall <$ insDhall'
-  T.<|> Clean <$ clean'
-  T.<|> Version <$ version'
-  T.<|> InitSpacchetti <$> initSpacchetti'
+      = Init <$> init'
   T.<|> Install <$ install'
   T.<|> Sources <$ sources'
   T.<|> Build <$ build'
+  T.<|> PscPackageLocalSetup <$> localSetup'
+  T.<|> PscPackageInsDhall <$ insDhall'
+  T.<|> PscPackageClean <$ clean'
+  T.<|> Version <$ version'
   where
     localSetup'
-      = T.subcommand "local-setup" "run project-local Spacchetti setup"
-      $ T.switch "force" 'f' "Overwrite any project found in the current directory."
+      = T.subcommand "psc-package-local-setup"
+          "Setup a local package set by creating a new packages.dhall"
+      $ T.switch "force" 'f' "Overwrite any project found in the current directory"
+
     insDhall'
-      = T.subcommand "insdhall" "insdhall the local package set from packages.dhall"
+      = T.subcommand "psc-package-insdhall"
+          "Insdhall the local package set from packages.dhall"
       $ pure ()
+
     clean'
-      = T.subcommand "clean" "Clean cached packages by deleting the .psc-package folder"
+      = T.subcommand "psc-package-clean"
+          "Clean cached packages by deleting the .psc-package folder"
       $ pure ()
-    initSpacchetti'
-      = T.subcommand "init" "initialize a Spacchetti project"
-      $ T.switch "force" 'f' "Overwrite any project found in the current directory."
+
+    init'
+      = T.subcommand "init"
+          "Initialize a new basic project"
+      $ T.switch "force" 'f' "Overwrite any project found in the current directory"
+
     install'
-      = T.subcommand "install" "Install a Spacchetti project from spacchetti.dhall"
+      = T.subcommand "install"
+          "Install (download) all dependencies listed in spago.dhall"
       $ pure ()
+
     sources'
-      = T.subcommand "sources" "Get globs of sources of dependencies of a Spacchetti project. Useful for editor plugins."
+      = T.subcommand "sources"
+          "List all the source paths (globs) for the dependencies of the project"
       $ pure ()
+
     build'
-      = T.subcommand "build" "Build a Spacchetti project"
+      = T.subcommand "build"
+          "Install the dependencies and compile the current package"
       $ pure ()
+
     version'
-      = T.subcommand "version" "Show spacchetti-cli version"
+      = T.subcommand "version"
+          "Show spago version"
       $ pure ()
 
 main :: IO ()
 main = do
   GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
-  command <- T.options "Spacchetti CLI" parser
+  command <- T.options "Spago - manage your PureScript projects" parser
   case command of
-    LocalSetup force -> localSetup force
-    InsDhall         -> insDhall
-    Clean            -> clean
-    InitSpacchetti f -> initSpacchetti f
-    Install          -> install
-    Sources          -> sources
-    Build            -> build
-    Version          -> printVersion
+    Init force                 -> Spago.init force
+    Install                    -> Spago.install
+    Sources                    -> Spago.sources
+    Build                      -> Spago.build
+    Version                    -> Spago.printVersion
+    PscPackageLocalSetup force -> PscPackage.localSetup force
+    PscPackageInsDhall         -> PscPackage.insDhall
+    PscPackageClean            -> PscPackage.clean

--- a/app/PscPackage.hs
+++ b/app/PscPackage.hs
@@ -1,22 +1,114 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module PscPackage where
 
-import GHC.Generics
-import Data.Text (Text)
-import Data.Aeson
-import Data.Aeson.TH
+import           Control.Exception  (SomeException, try)
+import qualified Data.Aeson         as JSON
+import           Data.Text          (Text)
+import qualified Data.Text          as Text
+import qualified Data.Text.Encoding as Text
+import qualified Dhall.Format       as Dhall.Format
+import qualified Dhall.Pretty       as Dhall.Pretty
+import qualified Turtle             as T
 
-data PscPackage = PscPackage
-  { name    :: Text
-  , set     :: Text
-  , source  :: Text
-  , depends :: [Text]
-  }
-  deriving (Show, Generic)
+import qualified PscPackage.Types   as PscPackage
+import           Spago.Dhall        (dhallToJSON)
+import qualified Spago.Templates    as Templates
 
-$(deriveJSON defaultOptions ''PscPackage)
+
+pscPackageBasePathText :: Text
+pscPackageBasePathText = ".psc-package/local/.set/"
+
+pscPackageBasePath :: T.FilePath
+pscPackageBasePath = T.fromText pscPackageBasePathText
+
+packagesDhallText :: Text
+packagesDhallText = "./packages.dhall"
+
+packagesDhallPath :: T.FilePath
+packagesDhallPath = T.fromText packagesDhallText
+
+packagesJsonText :: Text
+packagesJsonText = pscPackageBasePathText <> "packages.json"
+
+packagesJsonPath :: T.FilePath
+packagesJsonPath = T.fromText packagesJsonText
+
+
+-- | Generates a local `packages.json` from the current `packages.dhall`
+insDhall :: IO ()
+insDhall = do
+  isProject <- T.testfile packagesDhallPath
+  T.unless isProject $
+    T.die "Missing packages.dhall file. Run `spago psc-package-local-setup` first."
+  T.mktree pscPackageBasePath
+  T.touch packagesJsonPath
+
+  try (dhallToJSON packagesDhallPath packagesJsonPath) >>= \case
+    Right _ -> do
+      T.echo $ T.unsafeTextToLine $ "Wrote packages.json to " <> packagesJsonText
+      T.echo "Now you can run `psc-package install`."
+    Left (err :: SomeException) ->
+      T.die ("Failed to insdhall: " <> Text.pack (show err))
+
+
+-- | Tries to create the `packages.dhall` file. Fails when the file already exists,
+--   unless `--force` has been used.
+makePackagesDhall :: Bool -> Text -> IO ()
+makePackagesDhall force command = do
+  T.unless force $ do
+    hasPackagesDhall <- T.testfile packagesDhallPath
+    T.when hasPackagesDhall $ T.die
+       $ "Found " <> packagesDhallText <> ": there's already a project here. "
+      <> "Run `spago " <> command <> " --force` if you're sure you want to overwrite it."
+  T.touch packagesDhallPath
+  T.writeTextFile packagesDhallPath Templates.packagesDhall
+  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack packagesDhallText)
+
+
+-- | Tries to create the `psc-package.json` file. Existing dependencies are preserved,
+-- | unless `--force` has been used.
+makePscPackage :: Bool -> IO ()
+makePscPackage force = do
+  hasPscPackage <- T.testfile pscPackageJsonPath
+  if hasPscPackage && not force
+    then do
+      pscPackage <- T.readTextFile pscPackageJsonPath
+      case JSON.eitherDecodeStrict $ Text.encodeUtf8 pscPackage of
+        Left e -> T.die $ "The existing psc-package.json file is in the wrong format: " <>
+          Text.pack e
+        Right p -> do
+          T.writeTextFile pscPackageJsonPath $
+            Templates.encodePscPackage $ p { PscPackage.set = "local", PscPackage.source = "" }
+          T.echo "An existing psc-package.json file was found and upgraded to use local package sets."
+          T.echo $ "It's possible that some of the existing dependencies are not in the default spacchetti package set."
+
+    else do
+      T.touch pscPackageJsonPath
+      pwd <- T.pwd
+      let projectName = case T.toText $ T.filename pwd of
+            Left _  -> "my-project"
+            Right n -> n
+      T.writeTextFile pscPackageJsonPath $ Templates.pscPackageJson projectName
+
+  where
+    pscPackageJsonPath = T.fromText "psc-package.json"
+
+
+-- | Create `packages.dhall` and update `psc-package.json` to use the local set
+localSetup :: Bool -> IO ()
+localSetup force = do
+  makePackagesDhall force "psc-package-local-setup"
+  makePscPackage force
+  T.echo "Set up local Spacchetti packages."
+  T.echo "Run `spago psc-package-insdhall` to generate the package set."
+
+
+-- | Delete the .psc-package folder
+clean :: IO ()
+clean = do
+  let pscDir = "./.psc-package"
+  hasDir <- T.testdir pscDir
+  if hasDir
+    then do
+      T.rmtree pscDir
+      T.echo "Packages cache was cleaned."
+    else T.echo "Nothing to clean here."

--- a/app/PscPackage/Types.hs
+++ b/app/PscPackage/Types.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PscPackage.Types where
+
+import           Data.Aeson
+import           Data.Aeson.TH
+import           Data.Text     (Text)
+import           GHC.Generics
+
+data PscPackage = PscPackage
+  { name    :: Text
+  , set     :: Text
+  , source  :: Text
+  , depends :: [Text]
+  }
+  deriving (Show, Generic)
+
+$(deriveJSON defaultOptions ''PscPackage)

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -1,0 +1,176 @@
+module Spago where
+
+import           Control.Exception (throwIO, try)
+import qualified Data.List         as List
+import qualified Data.Map          as Map
+import           Data.Text         (Text)
+import qualified Data.Text         as Text
+import           Data.Version      (showVersion)
+import qualified Dhall.Format      as Dhall.Format
+import qualified Dhall.Pretty      as Dhall.Pretty
+import qualified Paths_spago       as Pcli
+import qualified System.Directory  as Dir
+import qualified Turtle            as T
+
+import qualified PscPackage
+import           Spago.Config
+import           Spago.Spacchetti  (Package (..), PackageName (..))
+import qualified Spago.Templates   as Templates
+
+
+echo' :: Text -> IO ()
+echo' = T.echo . T.unsafeTextToLine
+
+surroundQuote :: Text -> Text
+surroundQuote y = "\"" <> y <> "\""
+
+-- | The directory in which spago will put its tempfiles
+spagoDir :: Text
+spagoDir = ".spago/"
+
+spagoDhallText :: Text
+spagoDhallText = "spago.dhall"
+
+spagoDhallPath :: T.FilePath
+spagoDhallPath = T.fromText spagoDhallText
+
+
+-- | Copies over `spago.dhall` to set up a Spago project
+makeConfig :: Bool -> IO ()
+makeConfig force = do
+  -- Make sure .spago exists
+  T.mktree $ T.fromText spagoDir
+
+  T.unless force $ do
+    hasSpagoDhall <- T.testfile spagoDhallPath
+    T.when hasSpagoDhall $ T.die
+       $ "Found " <> spagoDhallText <> ": there's already a project here. "
+      <> "Run `spago init --force` if you're sure you want to overwrite it."
+  T.touch spagoDhallPath
+  T.writeTextFile spagoDhallPath Templates.spagoDhall
+
+  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack spagoDhallText)
+
+
+-- | Init a new Spago project:
+--   - create `packages.dhall` to manage the package set, overrides, etc
+--   - create `spago.dhall` to manage project config: name, deps, etc
+--   - create an example `src` folder
+--   - create an example `test` folder
+init :: Bool -> IO ()
+init force = do
+  PscPackage.makePackagesDhall force "init"
+  makeConfig force
+  T.mktree "src"
+  T.mktree "test"
+  T.writeTextFile "src/Main.purs" Templates.srcMain
+  T.writeTextFile "test/Main.purs" Templates.testMain
+  T.writeTextFile ".gitignore" Templates.gitignore
+  T.echo "Set up a local Spago project."
+  T.echo "Try running `spago install`"
+
+
+-- | Checks that the Spago config is there and readable
+ensureConfig :: IO Config
+ensureConfig = do
+  exists <- T.testfile spagoDhallPath
+  T.unless exists $ makeConfig False
+  configText <- T.readTextFile spagoDhallPath
+  try (parseConfig configText) >>= \case
+    Right config -> pure config
+    Left (err :: ConfigReadError) -> throwIO err
+
+
+-- | Returns the dir path for a given package
+getDir :: (PackageName, Package) -> Text
+getDir (PackageName{..}, Package{..})
+  = spagoDir <> packageName <> "/" <> version
+
+
+getGlobs :: [(PackageName, Package)] -> [Text]
+getGlobs = map (\pair -> getDir pair <> "/src/**/*.purs")
+
+
+getDep :: (PackageName, Package) -> IO ()
+getDep pair@(PackageName{..}, Package{..} ) = do
+  let dir = getDir pair
+  exists <- T.testdir $ T.fromText dir
+  if exists
+    then do
+      echo' $ surroundQuote packageName <> " already installed."
+    else do
+      echo' $ "Installing " <> surroundQuote packageName
+      T.mktree . T.fromText $ dir
+      Dir.withCurrentDirectory (Text.unpack dir) $ do
+        let
+          cmd = Text.intercalate " && "
+            [ "git init"
+            , "git remote add origin " <> repo
+            , "git fetch origin " <> version
+            , "git -c advice.detachedHead=false checkout FETCH_HEAD"
+            ]
+        -- Swallow stdout here, we don't want the whole git output.
+        -- stderr is still piped though, so we should get errors
+        try (T.sh $ T.inshell cmd T.empty) >>= \case
+          Right _ -> pure ()
+          Left (err :: T.ExitCode) -> do
+            T.rmtree $ T.fromText dir
+            T.die ("Failed to install dependency: " <> T.repr err)
+
+
+getAllDependencies :: Config -> [(PackageName, Package)]
+getAllDependencies Config { dependencies = deps, packages = pkgs } =
+  Map.toList $ List.foldl' go Map.empty deps
+  where
+    go acc dep
+      | Map.member dep acc = acc
+      | otherwise =
+          case Map.lookup dep pkgs of
+            -- lazy error handling, user gets crash
+            Nothing -> error $ "Package " <> show dep <> " was missing from the package set."
+            Just x@(Package { dependencies = innerDeps }) -> do
+              let newAcc = List.foldl' go acc innerDeps
+              Map.insert dep x newAcc
+
+
+-- | Fetch all dependencies into `.spago/`
+install :: IO ()
+install = do
+  config <- ensureConfig
+  let deps = getAllDependencies config
+  echo' $ "Installing " <> Text.pack (show $ List.length deps) <> " dependencies."
+  _ <- traverse getDep deps
+  T.echo "Installation complete."
+
+
+-- | Get source globs of dependencies listed in `spago.dhall`
+sources :: IO ()
+sources = do
+  config <- ensureConfig
+  let
+    deps = getAllDependencies config
+    globs = getGlobs deps
+  _ <- traverse (echo') globs
+  pure ()
+
+
+-- | Build the project with purs
+build :: IO ()
+build = do
+  config <- ensureConfig
+  let
+    deps = getAllDependencies config
+    globs = getGlobs deps <> ["src/**/*.purs", "test/**/*.purs"]
+    paths = Text.intercalate " " $ surroundQuote <$> globs
+    cmd = "purs compile " <> paths
+  code <- T.shell cmd T.empty
+  case code of
+    T.ExitSuccess -> T.echo "Build succeeded."
+    T.ExitFailure n -> do
+      T.die ("Failed to build:" <> T.repr n)
+
+
+-- | Print out Spago version
+printVersion :: IO ()
+printVersion =
+  echo' $ Text.pack $ showVersion Pcli.version

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -110,8 +110,7 @@ getDep pair@(PackageName{..}, Package{..} ) = do
             , "git -c advice.detachedHead=false checkout FETCH_HEAD"
             ]
         -- Swallow stdout here, we don't want the whole git output.
-        -- stderr is still piped though, so we should get errors
-        try (T.sh $ T.inshell cmd T.empty) >>= \case
+        try (T.sh (T.inshellWithErr cmd T.empty)) >>= \case
           Right _ -> pure ()
           Left (err :: T.ExitCode) -> do
             T.rmtree $ T.fromText dir

--- a/app/Spago/Dhall.hs
+++ b/app/Spago/Dhall.hs
@@ -1,0 +1,34 @@
+module Spago.Dhall where
+
+import qualified Data.Aeson.Encode.Pretty as JSON
+import qualified Data.ByteString.Lazy     as ByteString.Lazy
+import           Data.Text                (Text)
+import qualified Data.Text.Encoding       as Text
+import qualified Dhall.JSON               as Dhall.JSON
+import qualified Turtle                   as T
+
+
+unsafePathToText :: T.FilePath -> Text
+unsafePathToText p = case T.toText p of
+  Left t  -> t
+  Right t -> t
+
+
+-- | Given a path to a Dhall file and an output path to a JSON file,
+--   reads the Dhall, converts it, and writes it as JSON
+dhallToJSON :: T.FilePath -> T.FilePath -> IO ()
+dhallToJSON inputPath outputPath = do
+  let config = JSON.Config
+               { JSON.confIndent = JSON.Spaces 2
+               , JSON.confCompare = compare
+               , JSON.confNumFormat = JSON.Generic
+               , JSON.confTrailingNewline = False }
+
+  dhall <- T.readTextFile inputPath
+
+  json <- Dhall.JSON.codeToValue Dhall.JSON.NoConversion (unsafePathToText inputPath) dhall
+
+  T.writeTextFile outputPath
+    $ Text.decodeUtf8
+    $ ByteString.Lazy.toStrict
+    $ JSON.encodePretty' config json

--- a/app/Spago/Spacchetti.hs
+++ b/app/Spago/Spacchetti.hs
@@ -1,0 +1,27 @@
+module Spago.Spacchetti where
+
+import           Data.Aeson
+import           Data.Map     (Map)
+import           Data.Text    (Text)
+import qualified Dhall
+import           GHC.Generics (Generic)
+
+
+-- | Matches the packages definition of Spacchetti Package.dhall/psc-package
+newtype PackageName = PackageName { packageName :: Text }
+  deriving (Show)
+  deriving newtype (Eq, Ord, ToJSON, FromJSON, ToJSONKey, FromJSONKey, Dhall.Interpret)
+
+-- | A spacchetti package.
+data Package = Package
+  { dependencies :: [PackageName] -- ^ list of dependency package names
+  , repo         :: Text          -- ^ the git repository
+  , version      :: Text          -- ^ version string (also functions as a git ref)
+  }
+  deriving (Show, Generic)
+
+instance ToJSON Package
+instance FromJSON Package
+
+type Packages = Map PackageName Package
+

--- a/app/Spago/Templates.hs
+++ b/app/Spago/Templates.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
-module Templates where
 
-import Data.FileEmbed
-import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Encoding as LT
-import qualified Data.Text as T
-import Data.Aeson.Encode.Pretty
-import PscPackage (PscPackage)
-import qualified PscPackage as P
+module Spago.Templates where
+
+import           Data.Aeson.Encode.Pretty
+import           Data.FileEmbed
+import qualified Data.Text                as T
+import qualified Data.Text.Lazy           as LT
+import qualified Data.Text.Lazy.Encoding  as LT
+
+import           PscPackage.Types         (PscPackage (..))
 
 packagesDhall :: T.Text
 packagesDhall = $(embedStringFile "templates/packages.dhall")
 
-spacchettiDhall :: T.Text
-spacchettiDhall = $(embedStringFile "templates/spacchetti.dhall")
+spagoDhall :: T.Text
+spagoDhall = $(embedStringFile "templates/spago.dhall")
 
 srcMain :: T.Text
 srcMain = $(embedStringFile "templates/srcMain.purs")
@@ -29,4 +29,4 @@ encodePscPackage :: PscPackage -> T.Text
 encodePscPackage = LT.toStrict . LT.decodeUtf8 . encodePretty
 
 pscPackageJson :: T.Text -> T.Text
-pscPackageJson name = encodePscPackage $ P.PscPackage name "local" "" []
+pscPackageJson packageName = encodePscPackage $ PscPackage packageName "local" "" []

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,17 @@ ghc-options:
 # common to point users to the README.md file.
 description:         Please see the README on GitHub at <https://github.com/githubuser/spacchetti-cli#readme>
 
+default-extensions:
+- DeriveDataTypeable
+- DeriveGeneric
+- DerivingStrategies
+- DuplicateRecordFields
+- GeneralizedNewtypeDeriving
+- LambdaCase
+- RecordWildCards
+- ScopedTypeVariables
+- OverloadedStrings
+
 dependencies:
 - base >= 4.7 && < 5
 - text < 1.3

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
-name:                spacchetti-cli
-version:             0.5.0.0
-github:              "justinwoo/spacchetti-cli"
+name:                spago
+version:             0.6.0.0
+github:              "spacchetti/spago"
 license:             BSD3
-author:              "Justin Woo"
-maintainer:          "@jusrin00"
-copyright:           "2018 Justin Woo"
+author:              "Justin Woo, Fabrizio Ferrai"
+maintainer:          "@jusrin00, @fabferrai"
+copyright:           "2018 Justin Woo, Fabrizio Ferrai"
 
 extra-source-files:
 - README.md
@@ -20,7 +20,7 @@ ghc-options:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/githubuser/spacchetti-cli#readme>
+description:         Please see the README on GitHub at <https://github.com/spacchetti/spago#readme>
 
 default-extensions:
 - DeriveDataTypeable
@@ -49,7 +49,7 @@ dependencies:
 - prettyprinter
 
 executables:
-  spacchetti:
+  spago:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -58,7 +58,7 @@ executables:
     - -with-rtsopts=-N
 
 tests:
-  spacchetti-cli-test:
+  spago-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -42,11 +42,12 @@ dependencies:
 - aeson
 - aeson-pretty
 - containers
-- directory
 - dhall
 - dhall-json
 - bytestring
 - prettyprinter
+- async
+- process
 
 executables:
   spago:

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -7,4 +7,4 @@
 /.psc*
 /.purs*
 /.psa*
-/.spacchetti
+/.spago

--- a/templates/spago.dhall
+++ b/templates/spago.dhall
@@ -1,5 +1,5 @@
 {-
-Welcome to a Spacchetti project!
+Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name =

--- a/templates/srcMain.purs
+++ b/templates/srcMain.purs
@@ -7,4 +7,4 @@ import Effect.Console (log)
 
 main :: Effect Unit
 main = do
-  log "Hello Spacchetti!"
+  log "🍝"


### PR DESCRIPTION
Fix #23

This is mostly shuffling around stuff, things happening:
- rename to `spago`
- rewrite the README with a bunch more instructions on various commands
- add a `stylish-haskell` config
- split the responsibilities of working with a `psc-package` project and a `spago` project
- prefix the `psc-package`-related commands with `psc-package-` as mentioned in https://github.com/spacchetti/spacchetti-cli/issues/31#issuecomment-444475865
- fix #32 by fetching the repos concurrently
- fix #26 by implementing the commands from `purp`