### PR TITLE
Update packages.dhall template to the latest release

### DIFF
--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/justinwoo/spacchetti/24112018/src/mkPackage.dhall sha256:8e1c6636f8a089f972b21cde0cef4b33fa36a2e503ad4c77928aabf92d2d4ec9
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/mkPackage.dhall sha256:8e1c6636f8a089f972b21cde0cef4b33fa36a2e503ad4c77928aabf92d2d4ec9
 
 let upstream =
-      https://raw.githubusercontent.com/justinwoo/spacchetti/24112018/src/packages.dhall sha256:81454036f1779dbce007a69889ef10f3ecdb7bc8beb97d8d75931c8d87075ad1
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/packages.dhall sha256:c63285af67ae74feb2f6eb67521712441928d2726ea10e2040774849ca765027
 
 let overrides = {=}
 


### PR DESCRIPTION
This can actually be automated by having @spacchettibotti push a commit to this repo every time a release in Travis runs.

Steps for automating this:
- sed the new release name in the urls in `packages.dhall`, more sed to remove the `sha265:..`
- run `dhall freeze --inplace templates/packages.dhall`