### PR TITLE
Initial windows support changes

### DIFF
--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -278,7 +278,7 @@ bundle withMain maybeModuleName maybeTargetPath = do
         WithoutMain -> ""
 
       cmd
-        = "purs bundle './output/*/*.js'"
+        = "purs bundle \"output/*/*.js\""
         <> " -m " <> moduleName
         <> main
         <> " -o " <> targetPath

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,4 @@ extra-deps:
 - repline-0.2.0.0
 - async-pool-0.9.0.2
 - serialise-0.2.1.0
+- Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85


### PR DESCRIPTION
Solves getting compilation working, and making bundle work on windows as per #47 

PR'd for code review purposes, I'm not sure if these are the best solutions and won't cause issues for non windows machines.

Unfortunately the encoding issue seems trickier, I'm not sure whether embedding the template or writing it to disk is causing the bad characters to be created, and my research into this has failed (so I might need a haskell guru to help fix this part). I could just change packages.dhall to be ascii, but I feel like this is weak solution as dhall supports unicode, so we should be able to work with that template file.