### PR TITLE
Add option to pass arguments through to purs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,15 @@ This is just a thin layer above the PureScript compiler command `purs compile`.
 The build will produce very many JavaScript files in the `output/` folder. These
 are CommonJS modules, and you can just `require()` them e.g. on Node.
 
-However, you might want to get a single, executable file. You'd then use the following:
+**Note**: the wrapper on the compiler is so thin that you can pass options to `purs`.
+E.g. if you wish to output your files in some other place than `output/`, you can run
+
+```bash
+spago build -- -o myOutput/
+```
+
+Anyways, the above will create a whole lot of files, but you might want to get just a
+single, executable file. You'd then use the following:
 
 ```bash
 # You can specify the main module and the target file, or these defaults will be used

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -233,15 +233,17 @@ sources = do
   pure ()
 
 
--- | Build the project with purs
-build :: IO ()
-build = do
+-- | Build the project with purs, passing through
+--   the additional args in the list
+build :: [T.Text] -> IO ()
+build passthroughArgs = do
   config <- ensureConfig
   let
     deps  = getAllDependencies config
     globs = getGlobs deps <> ["src/**/*.purs", "test/**/*.purs"]
     paths = Text.intercalate " " $ surroundQuote <$> globs
-    cmd = "purs compile " <> paths
+    args  = Text.intercalate " " passthroughArgs
+    cmd = "purs compile " <> args <> " " <> paths
   T.shell cmd T.empty >>= \case
     T.ExitSuccess -> echo "Build succeeded."
     T.ExitFailure n -> do
@@ -256,9 +258,9 @@ data WithMain = WithMain | WithoutMain
 
 -- | Test the project: compile and run the Test.Main
 --   (or the provided module name) with node
-test :: Maybe ModuleName -> IO ()
-test maybeModuleName = do
-  build
+test :: Maybe ModuleName -> [T.Text] -> IO ()
+test maybeModuleName passthroughArgs = do
+  build passthroughArgs
   T.shell cmd T.empty >>= \case
     T.ExitSuccess   -> echo "Tests succeeded."
     T.ExitFailure n -> die $ "Tests failed: " <> T.repr n

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -50,10 +50,15 @@ expect_success(
 ## spago build
 
 expect_success(
+    ['spago', 'build', '--', '-o myOutput'],
+    "Spago should pass options to purs"
+)
+assert os.path.isdir('myOutput') == True
+
+expect_success(
     ['spago', 'build'],
     "Spago should build successfully"
 )
-
 
 ## spago test
 
@@ -86,6 +91,6 @@ check_fixture('module.js')
 ## Cleanup after tests
 
 expect_success(
-    ['rm', '-rf', '.spago', 'src', 'test', 'packages.dhall', 'spago.dhall', 'bundle.js', 'module.js', 'output'],
+    ['rm', '-rf', '.spago', 'src', 'test', 'packages.dhall', 'spago.dhall', 'bundle.js', 'module.js', 'output', 'myOutput'],
     "Cleanup should empty the project folder"
 )


### PR DESCRIPTION
With this we pass args through to `purs`, and this is now possible: `spago build -- -o myOutput`

Fix #49