### PR TITLE
Add build path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ PureScript package manager and build tool powered by [Dhall][dhall] and
 
 ## What does all of this mean?
 
-`spago` aims to tie together the UX of developing a PureScript project.  
+`spago` aims to tie together the UX of developing a PureScript project.
 In this Pursuit (see what I did there) it is heavily inspired by [Rust's Cargo][cargo]
 and [Haskell's Stack][stack], and builds on top of ideas from existing PureScript
 infrastructure and tooling, as [`psc-package`][psc-package], [`pulp`][pulp] and
@@ -46,9 +46,9 @@ The recommended installation methods on Linux and macOS are:
 - Compile from source by cloning this repo and running `stack install`
 
 **Note #1:** support for Windows is still basic, and we're sorry for this - the
-reason is that no current maintainer runs it.  
+reason is that no current maintainer runs it.
 Currently the only way to install on Windows is with `stack` - more info in
-[#57](https://github.com/spacchetti/spago/issues/57).  
+[#57](https://github.com/spacchetti/spago/issues/57).
 If you'd like to help with this that's awesome! Get in touch by commenting there
 or [opening another issue][spago-issues] :)
 
@@ -82,12 +82,12 @@ test files in `test/`.
 
 Let's take a look at the two [Dhall][dhall] configuration files that `spago` requires:
 - `packages.dhall`: this file is meant to contain the *totality* of the packages
-  available to your project (that is, any package you might want to import).  
+  available to your project (that is, any package you might want to import).
   In practical terms, it pulls in a [Spacchetti][spacchetti] package-set as a base,
   and you are then able to add any package that might not be in the package set,
   or override esisting ones.
 - `spago.dhall`: this is your project configuration. It includes the above package-set,
-  the list of your dependencies, and any other project-wide setting that `spago` will 
+  the list of your dependencies, and any other project-wide setting that `spago` will
   use for builds.
 
 ### Configuration file format
@@ -160,9 +160,16 @@ We can then build the project and its dependencies by running:
 $ spago build
 ```
 
-This is just a thin layer above the PureScript compiler command `purs compile`.  
+This is just a thin layer above the PureScript compiler command `purs compile`.
 The build will produce very many JavaScript files in the `output/` folder. These
 are CommonJS modules, and you can just `require()` them e.g. on Node.
+
+It's also possible to include custom source paths when building (`src` and `test` are always included):
+
+```bash
+$ spago build --path 'another_source/**/*.purs'
+
+```
 
 **Note**: the wrapper on the compiler is so thin that you can pass options to `purs`.
 E.g. if you wish to output your files in some other place than `output/`, you can run
@@ -220,7 +227,7 @@ Here's what we can do about it:
 ### `psc-package-local-setup`
 
 This command creates a `packages.dhall` file in your project, that points to the
-most recent Spacchetti package-set, and lets you override and add arbitrary packages.  
+most recent Spacchetti package-set, and lets you override and add arbitrary packages.
 See the Spacchetti docs about this [here][spacchetti-local-setup].
 
 ### `psc-package-insdhall`
@@ -250,16 +257,16 @@ Yees, however:
   versions together all the time).
 - If you use `psc-package`, you have the problem of not having the ability of overriding
   packages versions when needed, leading everyone to make their own package-set, which
-  then goes unmaintained, etc.  
+  then goes unmaintained, etc.
   Of course you can use [Spacchetti] to solve this issue, but this is exactly what
   we're doing here: integrating all the workflow in a single tool, `spago`, instead
   of having to use `pulp`, `psc-package`, `purp`, etc.
-  
+
 > So if I use `spago make-module` this thing will compile all my js deps in the file?
 
 No. We only take care of PureScript land. In particular, `make-module` will do the
 most we can do on the PureScript side of things (dead code elimination), but will
-leave the `require`s still in.  
+leave the `require`s still in.
 To fill them in you should use the proper js tool of the day, at the time of
 writing [ParcelJS][parcel] looks like a good option.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ data Command
   | Build [TargetPath] [T.Text]
 
   -- | Test the project with some module, default Test.Main
-  | Test (Maybe ModuleName) [T.Text]
+  | Test (Maybe ModuleName) [TargetPath] [T.Text]
 
   -- | Bundle the project, with optional main and target path arguments
   | Bundle (Maybe ModuleName) (Maybe TargetPath)
@@ -114,7 +114,7 @@ parser
 
     test
       = T.subcommand "test" "Test the project with some module, default Test.Main"
-      $ Test <$> mainModule <*> passthroughArgs
+      $ Test <$> mainModule <*> sourcePaths <*> passthroughArgs
 
     bundle
       = T.subcommand "bundle" "Bundle the project, with optional main and target path arguments"
@@ -139,14 +139,14 @@ main = do
 
   command <- T.options "Spago - manage your PureScript projects" parser
   case command of
-    Init force                 -> Spago.initProject force
-    Install limitJobs          -> Spago.install limitJobs
-    Sources                    -> Spago.sources
-    Build paths pursArgs       -> Spago.build paths pursArgs
-    Test modName pursArgs      -> Spago.test modName pursArgs
-    Bundle modName tPath       -> Spago.bundle WithMain modName tPath
-    MakeModule modName tPath   -> Spago.makeModule modName tPath
-    Version                    -> Spago.printVersion
-    PscPackageLocalSetup force -> PscPackage.localSetup force
-    PscPackageInsDhall         -> PscPackage.insDhall
-    PscPackageClean            -> PscPackage.clean
+    Init force                  -> Spago.initProject force
+    Install limitJobs           -> Spago.install limitJobs
+    Sources                     -> Spago.sources
+    Build paths pursArgs        -> Spago.build paths pursArgs
+    Test modName paths pursArgs -> Spago.test modName paths pursArgs
+    Bundle modName tPath        -> Spago.bundle WithMain modName tPath
+    MakeModule modName tPath    -> Spago.makeModule modName tPath
+    Version                     -> Spago.printVersion
+    PscPackageLocalSetup force  -> PscPackage.localSetup force
+    PscPackageInsDhall          -> PscPackage.insDhall
+    PscPackageClean             -> PscPackage.clean

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -258,9 +258,9 @@ data WithMain = WithMain | WithoutMain
 
 -- | Test the project: compile and run the Test.Main
 --   (or the provided module name) with node
-test :: Maybe ModuleName -> [T.Text] -> IO ()
-test maybeModuleName passthroughArgs = do
-  build [] passthroughArgs
+test :: Maybe ModuleName -> [TargetPath] -> [T.Text] -> IO ()
+test maybeModuleName paths passthroughArgs = do
+  build paths passthroughArgs
   T.shell cmd T.empty >>= \case
     T.ExitSuccess   -> echo "Tests succeeded."
     T.ExitFailure n -> die $ "Tests failed: " <> T.repr n

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -235,12 +235,12 @@ sources = do
 
 -- | Build the project with purs, passing through
 --   the additional args in the list
-build :: [T.Text] -> IO ()
-build passthroughArgs = do
+build :: [TargetPath] -> [T.Text] -> IO ()
+build sourcePaths passthroughArgs = do
   config <- ensureConfig
   let
     deps  = getAllDependencies config
-    globs = getGlobs deps <> ["src/**/*.purs", "test/**/*.purs"]
+    globs = getGlobs deps <> ["src/**/*.purs", "test/**/*.purs"] <> map unTargetPath sourcePaths
     paths = Text.intercalate " " $ surroundQuote <$> globs
     args  = Text.intercalate " " passthroughArgs
     cmd = "purs compile " <> args <> " " <> paths
@@ -260,7 +260,7 @@ data WithMain = WithMain | WithoutMain
 --   (or the provided module name) with node
 test :: Maybe ModuleName -> [T.Text] -> IO ()
 test maybeModuleName passthroughArgs = do
-  build passthroughArgs
+  build [] passthroughArgs
   T.shell cmd T.empty >>= \case
     T.ExitSuccess   -> echo "Tests succeeded."
     T.ExitFailure n -> die $ "Tests failed: " <> T.repr n

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -64,7 +64,7 @@ os.mkdir('another_source_path')
 os.rename('src/Main.purs', 'another_source_path/Main.purs')
 expect_success(
     ['spago', 'build', '--path', 'another_source_path/*.purs'],
-    "Spago should build successfully"
+    "Spago should build successfully sources included from custom path"
 )
 os.rename('another_source_path/Main.purs', 'src/Main.purs')
 

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -60,6 +60,14 @@ expect_success(
     "Spago should build successfully"
 )
 
+os.mkdir('another_source_path')
+os.rename('src/Main.purs', 'another_source_path/Main.purs')
+expect_success(
+    ['spago', 'build', '--path', 'another_source_path/*.purs'],
+    "Spago should build successfully"
+)
+os.rename('another_source_path/Main.purs', 'src/Main.purs')
+
 ## spago test
 
 expect_success(
@@ -91,6 +99,6 @@ check_fixture('module.js')
 ## Cleanup after tests
 
 expect_success(
-    ['rm', '-rf', '.spago', 'src', 'test', 'packages.dhall', 'spago.dhall', 'bundle.js', 'module.js', 'output', 'myOutput'],
+    ['rm', '-rf', '.spago', 'src', 'test', 'packages.dhall', 'spago.dhall', 'bundle.js', 'module.js', 'output', 'myOutput', 'another_source_path'],
     "Cleanup should empty the project folder"
 )


### PR DESCRIPTION
Adds a `--path` (`-p`) option for custom source paths.

E.g. `spago build --path 'another_source/**/*.purs'`

Fix #68 