### PR TITLE
Adds available command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,6 +27,9 @@ data Command
   --   or the specified target paths
   | Build [TargetPath] [T.Text]
 
+  -- | List available packages
+  | ListPackages
+
   -- | Test the project with some module, default Test.Main
   | Test (Maybe ModuleName) [TargetPath] [T.Text]
 
@@ -67,6 +70,7 @@ parser
       = initProject
   T.<|> install
   T.<|> sources
+  T.<|> listPackages
   T.<|> build
   T.<|> test
   T.<|> bundle
@@ -108,6 +112,10 @@ parser
       = T.subcommand "sources" "List all the source paths (globs) for the dependencies of the project"
       $ pure Sources
 
+    listPackages
+      = T.subcommand "list-packages" "List packages available in your packages.dhall"
+      $ pure ListPackages
+
     build
       = T.subcommand "build" "Install the dependencies and compile the current package"
       $ Build <$> sourcePaths <*> passthroughArgs
@@ -141,6 +149,7 @@ main = do
   case command of
     Init force                  -> Spago.initProject force
     Install limitJobs           -> Spago.install limitJobs
+    ListPackages                -> Spago.listPackages
     Sources                     -> Spago.sources
     Build paths pursArgs        -> Spago.build paths pursArgs
     Test modName paths pursArgs -> Spago.test modName paths pursArgs

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -7,6 +7,7 @@ module Spago
   , bundle
   , makeModule
   , printVersion
+  , listPackages
   , ModuleName(..)
   , TargetPath(..)
   , WithMain(..)
@@ -135,7 +136,6 @@ getPackageDir :: (PackageName, Package) -> Text
 getPackageDir (PackageName{..}, Package{..})
   = spagoDir <> packageName <> "/" <> version
 
-
 getGlobs :: [(PackageName, Package)] -> [Text]
 getGlobs = map (\pair -> getPackageDir pair <> "/src/**/*.purs")
 
@@ -189,7 +189,6 @@ getAllDependencies Config { dependencies = deps, packages = pkgs } =
               let newAcc = List.foldl' go acc innerDeps
               Map.insert dep x newAcc
 
-
 -- | Fetch all dependencies into `.spago/`
 install :: Maybe Int -> IO ()
 install maybeLimit = do
@@ -220,6 +219,22 @@ install maybeLimit = do
     -- We run a pretty high amount of threads by default, but this can be
     -- limited by specifying an option
     limit = fromMaybe 100 maybeLimit
+
+-- | A list of the packages that can be added to this project
+listPackages :: IO ()
+listPackages = do
+    config <- ensureConfig
+    let names = getPackageNames config
+    _ <- traverse echo names
+    pure ()
+
+    where
+      -- | Get all the package names from the configuration
+      getPackageNames :: Config -> [Text]
+      getPackageNames Config {packages = pkgs } =
+        map toText $ Map.toList pkgs
+      toText (PackageName{..},Package{..}) =
+         packageName <> " (" <> version <> ", " <> repo <> ")"
 
 
 -- | Get source globs of dependencies listed in `spago.dhall`


### PR DESCRIPTION
This formats and works much like psc-packages available command,
but lists the packages that could be added to install.

I felt like I missed this from psc-package, so here is spagos version. 
I typically used psc-package available | grep packageiwaslookingfor.
Happy to close if this is against the vision of spago.

Example:
> spago available
> aff (v5.0.2, https://github.com/slamdata/purescript-aff.git)
> aff-coroutines (v7.0.0, https://github.com/purescript-contrib/purescript-aff-coroutines.git)
> aff-promise (v2.0.1, https://github.com/nwolverson/purescript-aff-promise.git)
> affjax (v7.0.0, https://github.com/slamdata/purescript-affjax.git)
> ansi (v5.0.0, https://github.com/hdgarrood/purescript-ansi.git)
> argonaut (v5.0.0, https://github.com/purescript-contrib/purescript-argonaut.git)
> argonaut-codecs (v5.1.0, https://github.com/purescript-contrib/purescript-argonaut-codecs.git)
> argonaut-core (v4.0.1, https://github.com/purescript-contrib/purescript-argonaut-core.git)
> argonaut-generic (v3.0.0, https://github.com/purescript-contrib/purescript-argonaut-generic.git)
> argonaut-traversals (v6.0.0, https://github.com/purescript-contrib/purescript-argonaut-traversals.git)
> arraybuffer-types (v2.0.0, https://github.com/purescript-contrib/purescript-arraybuffer-types.git)
> arrays (v5.1.1, https://github.com/purescript/purescript-arrays.git)
> assert (v4.0.0, https://github.com/purescript/purescript-assert.git)
> avar (v3.0.0, https://github.com/slamdata/purescript-avar.git)