### PR TITLE
wip: add packages to spago dhall

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -90,7 +90,7 @@ parser
     toTarget    = T.optional (T.opt (Just . TargetPath) "to" 't' "The target file path")
     limitJobs   = T.optional (T.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     sourcePaths = T.many (T.opt (Just . SourcePath) "path" 'p' "Source path to include")
-    packageName = T.many $ T.arg (Just . PackageName) "PACKAGE" "Name in package set"
+    packageNames = T.many $ T.arg (Just . PackageName) "package" "Package name to add as dependency"
     passthroughArgs = T.many $ T.arg (Just . PursArg) " ..any `purs` option" "Options passed through to `purs`; use -- to separate"
 
     pscPackageLocalSetup
@@ -111,7 +111,7 @@ parser
 
     install
       = T.subcommand "install" "Install (download) all dependencies listed in spago.dhall"
-      $ Install <$> limitJobs <*> packageName
+      $ Install <$> limitJobs <*> packageNames
 
     sources
       = T.subcommand "sources" "List all the source paths (globs) for the dependencies of the project"
@@ -157,7 +157,7 @@ main = do
   command <- T.options "Spago - manage your PureScript projects" parser
   case command of
     Init force                            -> Spago.initProject force
-    Install limitJobs packageName         -> Spago.install limitJobs packageName
+    Install limitJobs packageNames        -> Spago.install limitJobs packageNames
     ListPackages                          -> Spago.listPackages
     Sources                               -> Spago.sources
     Build limitJobs paths pursArgs        -> Spago.build limitJobs paths pursArgs

--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -236,5 +236,20 @@ addRawDeps newDeps config = config
 
 -- | Adds the `name` dependency to the "dependencies" list in the Config,
 --   sorts the dependencies, and writes the Config to file.
-addDependencies :: [PackageName] -> IO ()
-addDependencies = withConfigAST . addRawDeps
+addDependencies :: Config -> [PackageName] -> IO ()
+addDependencies config newPackages = do 
+  let notInPackageSet = mapMaybe
+        (\p -> case Map.lookup p (packages config) of
+                Just _  -> Nothing
+                Nothing -> Just p)
+        newPackages
+  case notInPackageSet of
+  -- If no packages are not in our set, add them to existing dependencies
+    []   -> withConfigAST $ addRawDeps newPackages
+    pkgs -> echo
+              ( "\nSome of the dependencies you tried to add "
+              <> "were not found in spacchetti's package set.\n"
+              <> "Not adding new dependencies to your new spago config. "
+              <> "We didn't find:\n"
+              <> (Text.intercalate "\n" $ map (\p -> "- " <> packageName p) pkgs)
+              <> "\n")


### PR DESCRIPTION
Motivation here is to be similar to psc-package,
being able to 'add' and item to your spago.dhall
with `spago install affjax` (end goal)

Not sure if this the best approach. Might be better to load the spago config, add the package, and write a serialization path to write it into spago.dhall.

Also not sure if being an extra argument/mode to install is the way to go. It makes it like psc-package, so the tools 'feel' like each other, but could also be confusing.


