### PR TITLE
0.6.2 → 0.6.3

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                spago
-version:             0.6.2.1
+version:             0.6.3.0
 github:              "spacchetti/spago"
 license:             BSD3
 author:              "Justin Woo, Fabrizio Ferrai"


### PR DESCRIPTION
Update the README with some info about the new commands:
- `spago repl`
- `spago list-packages`
- and some other info about overriding and adding packages to the package set