### PR TITLE
Fixes spago test in windows

### DIFF
--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -291,7 +291,7 @@ test maybeModuleName paths passthroughArgs = do
     T.ExitFailure n -> die $ "Tests failed: " <> T.repr n
   where
     moduleName = fromMaybe (ModuleName "Test.Main") maybeModuleName
-    cmd = "node -e 'require(\"./output/" <> unModuleName moduleName <> "\").main()'"
+    cmd = "node -e \"require('./output/" <> unModuleName moduleName <> "').main()\""
 
 
 prepareBundleDefaults :: Maybe ModuleName -> Maybe TargetPath -> (ModuleName, TargetPath)


### PR DESCRIPTION
So here's a weird issue on windows.
`spago test` never ran any tests, and reported tests succeeded.

Seems to be due to how the command is quoted, swapping them around works, but I'm not certain if this
may cause other clients to break.


