### PR TITLE
Upgrade to LTS 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     compiler: ": #stack default osx"
     os: osx
 
+env:
+  - IMAGE_TAG=lts-13
 
 before_install:
   # Using compiler above sets CC to an invalid value, so unset it
@@ -47,8 +49,8 @@ before_install:
       echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
     
     else
-      docker pull nilrecurring/haskell-lavello:lts-12
-      docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind nilrecurring/haskell-lavello:lts-12 /bin/bash -c "sudo chown -R ubuntu spago; cd spago; stack build"
+      docker pull "nilrecurring/haskell-lavello:${IMAGE_TAG}"
+      docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind "nilrecurring/haskell-lavello:${IMAGE_TAG}" /bin/bash -c "sudo chown -R ubuntu spago; cd spago; stack build"
     
     fi
 
@@ -81,7 +83,7 @@ script:
       stack build --copy-bins --local-bin-path ./artifacts;
       nvm install 10 && nvm use 10
     else
-      docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind nilrecurring/haskell-lavello:lts-12 /bin/bash -c "cd spago; stack build --copy-bins --local-bin-path ./artifacts"
+      docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind "nilrecurring/haskell-lavello:${IMAGE_TAG}" /bin/bash -c "cd spago; stack build --copy-bins --local-bin-path ./artifacts"
     fi
   - export PATH="${PATH}:$(pwd)/artifacts"
   - npm install -g purescript@0.12.1
@@ -102,7 +104,7 @@ before_deploy:
       then
         stack build --copy-bins --local-bin-path ./artifacts;
       else
-        docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind nilrecurring/haskell-lavello:lts-12 /bin/bash -c "cd spago; stack build --copy-bins --local-bin-path ./artifacts"
+        docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind "nilrecurring/haskell-lavello:${IMAGE_TAG}" /bin/bash -c "cd spago; stack build --copy-bins --local-bin-path ./artifacts"
       fi
       cp artifacts/spago spago
       tar -zcvf "${TRAVIS_OS_NAME}.tar.gz" spago

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,14 @@ services:
 
 matrix:
   include:
-  # BBuild on Linux with docker
-  - env: BUILD=stack ARGS=""
+  # Build on Linux with docker
+  - env: BUILD=stack ARGS="" IMAGE_TAG=lts-13
     compiler: ": #stack default"
 
   # Build on macOS natively
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default osx"
     os: osx
-
-env:
-  - IMAGE_TAG=lts-13
 
 before_install:
   # Using compiler above sets CC to an invalid value, so unset it

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,11 @@
 resolver: lts-13.0
 packages:
 - .
-- location:
-    git: https://github.com/f-f/async-pool
-    commit: 5f5635af5061ada0498fd04482efbab328c4775b
-  extra-dep: true
 extra-deps:
 - dhall-1.20.0
 - dhall-json-1.2.6
 - fgl-5.7.0.1
 #- async-pool-0.9.0.2
+- git: https://github.com/f-f/async-pool
+  commit: 5f5635af5061ada0498fd04482efbab328c4775b
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,17 @@
-resolver: lts-13.0
+resolver: lts-13.4
 packages:
 - .
 extra-deps:
-- dhall-1.20.1
-- dhall-json-1.2.6
+# Pinning to a commit due to https://github.com/dhall-lang/dhall-haskell/issues/788
+#- dhall-1.20.1
+#- dhall-json-1.2.6
+- git: https://github.com/dhall-lang/dhall-haskell
+  commit: 095ee6db61f858acd5ff04fddabc7dfcca6be365
+  subdirs:
+  - dhall
+  - dhall-json
 - fgl-5.7.0.1
+# Waiting for a release with the new base upper bounds
 #- async-pool-0.9.0.2
 - git: https://github.com/f-f/async-pool
   commit: 5f5635af5061ada0498fd04482efbab328c4775b

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-13.4
 packages:
 - .
 extra-deps:
+
 # Pinning to a commit due to https://github.com/dhall-lang/dhall-haskell/issues/788
 #- dhall-1.20.1
 #- dhall-json-1.2.6
@@ -10,9 +11,11 @@ extra-deps:
   subdirs:
   - dhall
   - dhall-json
-- fgl-5.7.0.1
+
 # Waiting for a release with the new base upper bounds
 #- async-pool-0.9.0.2
 - git: https://github.com/f-f/async-pool
   commit: 5f5635af5061ada0498fd04482efbab328c4775b
+
+- process-1.6.5.0
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-13.0
 packages:
 - .
 extra-deps:
-- dhall-1.20.0
+- dhall-1.20.1
 - dhall-json-1.2.6
 - fgl-5.7.0.1
 #- async-pool-0.9.0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,13 @@
-resolver: lts-12.21
+resolver: lts-13.0
 packages:
 - .
+- location:
+    git: https://github.com/f-f/async-pool
+    commit: 5f5635af5061ada0498fd04482efbab328c4775b
+  extra-dep: true
 extra-deps:
-- dhall-1.19.1
-- dhall-json-1.2.5
-- dotgen-0.4.2
-- megaparsec-7.0.3
-- repline-0.2.0.0
-- async-pool-0.9.0.2
-- serialise-0.2.1.0
+- dhall-1.20.0
+- dhall-json-1.2.6
+- fgl-5.7.0.1
+#- async-pool-0.9.0.2
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/mkPackage.dhall sha256:8e1c6636f8a089f972b21cde0cef4b33fa36a2e503ad4c77928aabf92d2d4ec9
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/mkPackage.dhall sha256:90974a8e07650e49a4197d4ce5b59e82740fd8469c8c1b9793939845ca8faad9
 
 let upstream =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/packages.dhall sha256:c63285af67ae74feb2f6eb67521712441928d2726ea10e2040774849ca765027
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/packages.dhall sha256:04da9c924e05cb6b43447ffd13408d01992f3172eb80d5d94e7f1b14c76a5123
 
 let overrides = {=}
 


### PR DESCRIPTION
We switch to lts-13 (fresh packages, yay!) and pin the Dhall version to fix a bug mentioned in #63 about Dhall breaking if `$HOME` is not found.