### PR TITLE
Upgrade Dhall to latest master to fix spago dying when HOME is unset

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,15 @@ resolver: lts-12.21
 packages:
 - .
 extra-deps:
-- dhall-1.19.1
-- dhall-json-1.2.5
+
+# Pinning to a commit due to https://github.com/dhall-lang/dhall-haskell/issues/788
+- git: https://github.com/dhall-lang/dhall-haskell
+  commit: 095ee6db61f858acd5ff04fddabc7dfcca6be365
+  subdirs:
+  - dhall
+  - dhall-json
+- cborg-json-0.2.1.0@sha256:af9137557002ca5308fe80570a9a29398dfb9708423870875223796760689ac3
+
 - dotgen-0.4.2
 - megaparsec-7.0.3
 - repline-0.2.0.0

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/mkPackage.dhall sha256:8e1c6636f8a089f972b21cde0cef4b33fa36a2e503ad4c77928aabf92d2d4ec9
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/mkPackage.dhall sha256:90974a8e07650e49a4197d4ce5b59e82740fd8469c8c1b9793939845ca8faad9 
 
 let upstream =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20181209/src/packages.dhall sha256:c63285af67ae74feb2f6eb67521712441928d2726ea10e2040774849ca765027
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/packages.dhall sha256:04da9c924e05cb6b43447ffd13408d01992f3172eb80d5d94e7f1b14c76a5123 
 
 let overrides = {=}
 


### PR DESCRIPTION
Pin the Dhall version to fix a bug mentioned in #63 about Dhall breaking if $HOME is not found.