### PR TITLE
Add command to upgrade the package-set if the upstream is Spacchetti

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 matrix:
   include:
-  # BBuild on Linux with docker
+  # Build on Linux with docker
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
 
@@ -84,6 +84,7 @@ script:
       docker run --mount src="$(pwd)",target=/home/ubuntu/spago,type=bind nilrecurring/haskell-lavello:lts-12 /bin/bash -c "cd spago; stack build --copy-bins --local-bin-path ./artifacts"
     fi
   - export PATH="${PATH}:$(pwd)/artifacts"
+  - ./scripts/check-spacchetti-version
   - npm install -g purescript@0.12.1
   - cd test/spago-test/ && python3 ../spago-test.py && cd ../../
   - npm install -g psc-package@3.0.1

--- a/README.md
+++ b/README.md
@@ -237,6 +237,26 @@ Once you verify that your application builds with the added packages, we would o
 course very much love if you could pull request it to the Upstream package-set,
 [spacchetti][spacchetti] ❤️🍝
 
+#### Upgrading the Package Set
+
+The version of the package-set you depend on is fixed in the `packages.dhall` file
+(look for the `upstream` var).
+
+You can upgrade to the latest version of Spacchetti with the `spacchetti-upgrade`
+command, that will automatically find out the latest version, download it, and write
+the new url and hashes in the `packages.dhall` file for you.
+
+Running it would look something like this:
+
+```bash
+$ spago spacchetti-upgrade
+Found the most recent tag for "spacchetti": 20190131
+Trying to read "packages.dhall"
+Package-set upgraded to latest tag "20190131"
+Fetching the new one and generating hashes.. (this might take some time)
+Done. Updating the local package-set file..
+```
+
 ### Building, bundling and testing a project
 
 We can then build the project and its dependencies by running:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,8 +6,9 @@ import qualified Turtle             as T
 
 import qualified PscPackage
 import           Spago              (ModuleName (..), PursArg (..), SourcePath (..),
-                                     TargetPath (..), WithMain(..))
+                                     TargetPath (..), WithMain (..))
 import qualified Spago
+import qualified Spago.Config
 
 
 -- | Commands that this program handles
@@ -43,6 +44,8 @@ data Command
   -- | Bundle a module into a CommonJS module
   | MakeModule (Maybe ModuleName) (Maybe TargetPath)
 
+  -- | Upgrade the package-set to the latest release
+  | SpacchettiUpgrade
 
   -- | ### Commands for working with Psc-Package
   --
@@ -80,6 +83,7 @@ parser
   T.<|> test
   T.<|> bundle
   T.<|> makeModule
+  T.<|> spacchettiUpgrade
   T.<|> pscPackageLocalSetup
   T.<|> pscPackageInsDhall
   T.<|> pscPackageClean
@@ -141,6 +145,10 @@ parser
       = T.subcommand "make-module" "Bundle a module into a CommonJS module"
       $ MakeModule <$> mainModule <*> toTarget
 
+    spacchettiUpgrade
+      = T.subcommand "spacchetti-upgrade" "Upgrade \"packages.dhall\" to the latest Spacchetti release"
+      $ pure SpacchettiUpgrade
+
     version
       = T.subcommand "version" "Show spago version"
       $ pure Version
@@ -165,7 +173,8 @@ main = do
     Repl paths pursArgs                   -> Spago.repl paths pursArgs
     Bundle modName tPath                  -> Spago.bundle WithMain modName tPath
     MakeModule modName tPath              -> Spago.makeModule modName tPath
+    SpacchettiUpgrade                     -> Spago.Config.upgradeSpacchetti
     Version                               -> Spago.printVersion
-    PscPackageLocalSetup force  -> PscPackage.localSetup force
-    PscPackageInsDhall          -> PscPackage.insDhall
-    PscPackageClean             -> PscPackage.clean
+    PscPackageLocalSetup force            -> PscPackage.localSetup force
+    PscPackageInsDhall                    -> PscPackage.insDhall
+    PscPackageClean                       -> PscPackage.clean

--- a/app/PscPackage.hs
+++ b/app/PscPackage.hs
@@ -27,7 +27,7 @@ pscPackageBasePath :: T.FilePath
 pscPackageBasePath = T.fromText pscPackageBasePathText
 
 packagesDhallText :: Text
-packagesDhallText = "./packages.dhall"
+packagesDhallText = "packages.dhall"
 
 packagesDhallPath :: T.FilePath
 packagesDhallPath = T.fromText packagesDhallText

--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -324,8 +324,8 @@ upgradeSpacchetti = do
             echo $ "Package-set upgraded to latest tag "
               <> surroundQuote releaseTagName
               <> "\nFetching the new one and generating hashes.. (this might take some time)"
-            frozenMkPackages <- Dhall.Freeze.hashImport "." defaultStandardVersion mkPackage
-            frozenUpstream   <- Dhall.Freeze.hashImport "." defaultStandardVersion upstream
+            frozenMkPackages <- Dhall.Freeze.freezeImport "." defaultStandardVersion mkPackage
+            frozenUpstream   <- Dhall.Freeze.freezeImport "." defaultStandardVersion upstream
             pure $ RawPackages frozenMkPackages frozenUpstream
   where
     -- | Given an import and a new Spacchetti tag, upgrades the import to

--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -2,6 +2,7 @@ module Spago.Config
   ( makeConfig
   , ensureConfig
   , addDependencies
+  , upgradeSpacchetti
   , Config(..)
   ) where
 
@@ -11,6 +12,7 @@ import qualified Data.Aeson                as JSON
 import           Data.Either               (lefts, rights)
 import           Data.Foldable             (toList)
 import qualified Data.List                 as List
+import           Data.List.NonEmpty        (NonEmpty (..))
 import qualified Data.Map                  as Map
 import           Data.Maybe                (mapMaybe)
 import qualified Data.Sequence             as Seq
@@ -19,7 +21,9 @@ import qualified Data.Text                 as Text
 import qualified Data.Text.Encoding        as Text
 import           Data.Text.Prettyprint.Doc (Pretty)
 import           Data.Typeable             (Typeable)
+import           Dhall.Binary              (defaultStandardVersion)
 import qualified Dhall.Format
+import qualified Dhall.Freeze
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Parser              as Parser
@@ -27,9 +31,10 @@ import qualified Dhall.Pretty
 import           Dhall.TypeCheck           (X)
 import qualified Dhall.TypeCheck
 import           GHC.Generics              (Generic)
+import qualified GitHub
 import qualified Turtle                    as T hiding (die, echo)
 
-import qualified PscPackage                as PscPkg
+import qualified PscPackage                as PscPackage
 import qualified PscPackage.Types          as PscPackage
 import qualified Spago.Config.Dhall        as Dhall
 import           Spago.Spacchetti          (Package, PackageName (..), Packages)
@@ -130,10 +135,10 @@ makeConfig force = do
 
   -- We try to find an existing psc-package config, and we migrate the existing
   -- content if we found one, otherwise we copy the default template
-  pscfileExists <- T.testfile PscPkg.configPath
+  pscfileExists <- T.testfile PscPackage.configPath
   T.when pscfileExists $ do
     -- first, read the psc-package file content
-    content <- T.readTextFile PscPkg.configPath
+    content <- T.readTextFile PscPackage.configPath
     case JSON.eitherDecodeStrict $ Text.encodeUtf8 content of
       Left _err -> do
         echo ( "Warning: found a \"psc-package.json\" file, "
@@ -238,3 +243,116 @@ addRawDeps newDeps config = config
 --   sorts the dependencies, and writes the Config to file.
 addDependencies :: [PackageName] -> IO ()
 addDependencies = withConfigAST . addRawDeps
+
+
+
+-- | Takes a function that manipulates the Dhall AST of the PackageSet,
+--   and tries to run it on the current packages.dhall
+--   If it succeeds, it writes back to file the result returned.
+--   Note: it will pass in the parsed AST, not the resolved one (so
+--   e.g. imports will still be in the tree). If you need the resolved
+--   one, use `ensureConfig`.
+withPackageSetAST :: (RawPackages -> IO RawPackages) -> IO ()
+withPackageSetAST transform = do
+  -- get a workable configuration
+  exists <- T.testfile PscPackage.packagesDhallPath
+  T.unless exists $ PscPackage.makePackagesDhall False "" -- TODO pass command here?
+  packageSetText <- T.readTextFile PscPackage.packagesDhallPath
+
+  -- parse the config without resolving imports
+  echo $ "Trying to read " <> surroundQuote PscPackage.packagesDhallText
+  (header, expr) <- case Parser.exprAndHeaderFromText mempty packageSetText of
+    Left  err -> throwIO err
+    Right (comment, ast) -> case Dhall.denote ast of
+      -- remove Note constructors, and match on the `let` shape
+      Dhall.Let
+        (Dhall.Binding "mkPackage" ann1 (Dhall.Embed mkPackageImport)
+          :| (Dhall.Binding "upstream" ann2 (Dhall.Embed upstreamImport)):rest)
+        body
+        -> do
+        -- run the transform on the package set
+        RawPackages{..} <- transform $ RawPackages mkPackageImport upstreamImport
+        -- rebuild it
+        pure $ (,) comment
+          $ Dhall.Let
+              (Dhall.Binding "mkPackage" ann1 (Dhall.Embed mkPackage)
+                :| (Dhall.Binding "upstream" ann2 (Dhall.Embed upstream)):rest)
+              body
+
+      e -> do
+        echo $ "Error while trying to parse "
+          <> surroundQuote PscPackage.packagesDhallText
+          <> ". Details:\n"
+        throwIO $ Dhall.CannotParsePackageSet e
+
+  -- After modifying the expression, we have to check if it still typechecks
+  -- if it doesn't we don't write to file
+  resolvedExpr <- Dhall.Import.load expr
+  case Dhall.TypeCheck.typeOf resolvedExpr of
+    Left  err -> throwIO err
+    Right _   -> do
+      echo "Done. Updating the local package-set file.."
+      T.writeTextFile PscPackage.packagesDhallPath
+        $ Dhall.prettyWithHeader header expr <> "\n"
+
+
+-- | Tries to upgrade the Spacchetti release of the local package set.
+--   It will:
+--   - try to read the latest tag from GitHub
+--   - try to read the current package-set file
+--   - try to replace the Spacchetti tag to which the package-set imports point to
+--     (if they point to the Spacchetti repo. This can be eventually made GitHub generic)
+--   - if all of this succeeds, it will regenerate the hashes and write to file
+upgradeSpacchetti :: IO ()
+upgradeSpacchetti = do
+  (GitHub.executeRequest' $ GitHub.latestReleaseR "spacchetti" "spacchetti") >>= \case
+    Left err -> do
+      echo "Could not reach GitHub. Error:\n"
+      throwIO err
+    Right GitHub.Release{..} -> do
+      echo ("Found the most recent tag for \"spacchetti\": " <> releaseTagName)
+      withPackageSetAST $ \packagesRaw -> do
+        maybePackages <- pure $ do
+          newMkPackages <- upgradeImport releaseTagName $ mkPackage packagesRaw
+          newUpstream   <- upgradeImport releaseTagName $ upstream packagesRaw
+          pure $ RawPackages newMkPackages newUpstream
+        case maybePackages of
+          Left wrongImport ->
+            throwIO $ (Dhall.ImportCannotBeUpdated wrongImport :: Dhall.ReadError Dhall.Import)
+          -- If everything is fine, refreeze the imports
+          Right RawPackages{..} -> do
+            echo $ "Package-set upgraded to latest tag "
+              <> surroundQuote releaseTagName
+              <> "\nFetching the new one and generating hashes.. (this might take some time)"
+            frozenMkPackages <- Dhall.Freeze.hashImport "." defaultStandardVersion mkPackage
+            frozenUpstream   <- Dhall.Freeze.hashImport "." defaultStandardVersion upstream
+            pure $ RawPackages frozenMkPackages frozenUpstream
+  where
+    -- | Given an import and a new Spacchetti tag, upgrades the import to
+    --   the tag and resets the hash
+    upgradeImport :: Text -> Dhall.Import -> Either Dhall.Import Dhall.Import
+    upgradeImport newTag Dhall.Import
+      { importHashed = Dhall.ImportHashed
+        { importType = Dhall.Remote Dhall.URL
+          -- Check if we're dealing with the Spacchetti repo
+          { authority = "raw.githubusercontent.com"
+          , path = Dhall.File
+            { directory = Dhall.Directory
+              { components = [ "src", _currentTag, "spacchetti", "spacchetti" ]}
+            , ..
+            }
+          , ..
+          }
+        , ..
+        }
+      , ..
+      } =
+      let components = [ "src", newTag, "spacchetti", "spacchetti" ]
+          directory = Dhall.Directory{..}
+          newPath = Dhall.File{..}
+          authority = "raw.githubusercontent.com"
+          importType = Dhall.Remote Dhall.URL { path = newPath, ..}
+          newHash = Nothing -- Reset the hash here, as we'll refreeze
+          importHashed = Dhall.ImportHashed { hash = newHash, ..}
+      in Right Dhall.Import{..}
+    upgradeImport _ imp = Left imp

--- a/app/Spago/Turtle.hs
+++ b/app/Spago/Turtle.hs
@@ -28,7 +28,7 @@ echo = Turtle.printf (Turtle.s Turtle.% "\n")
 echoStr :: String -> IO ()
 echoStr = echo . Text.pack
 
-die :: Text -> IO ()
+die :: Text -> IO a
 die reason = throwIO $ SpagoError reason
 
 surroundQuote :: Text -> Text

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
 - async-pool
 - process
 - template-haskell
+- github
 
 executables:
   spago:

--- a/scripts/check-spacchetti-version
+++ b/scripts/check-spacchetti-version
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+
+# Get the latest spacchetti tag
+export UPSTREAM_TAG=$(wget -q -O - https://github.com/spacchetti/spacchetti/releases/latest --server-response --max-redirect 0 2>&1 | sed -n -e 's/.*Location:.*tag\///p')
+
+# Then get the tag in the current template
+export CURRENT_TAG=$(cat templates/packages.dhall | grep "packages.dhall"  | sed -e "s|.*/spacchetti/spacchetti/||g" | sed "s|/src.*||g")
+
+
+error_text=$(cat <<-END
+
+The Spacchetti version in spago's template is outdated, let's upgrade it.
+
+Current tag:  $CURRENT_TAG
+Upstream tag: $UPSTREAM_TAG
+
+To fix this, run the following command in your spago repo:
+
+>>> cd templates && spago spacchetti-upgrade
+
+END
+)
+
+
+# If it's not the same, fail and ask the user to update it
+if [ "$UPSTREAM_TAG" != "$CURRENT_TAG" ]; then
+    echo "$error_text"
+    exit 1
+fi

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/mkPackage.dhall sha256:90974a8e07650e49a4197d4ce5b59e82740fd8469c8c1b9793939845ca8faad9 
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190131/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/20190105/src/packages.dhall sha256:04da9c924e05cb6b43447ffd13408d01992f3172eb80d5d94e7f1b14c76a5123 
+      https://raw.githubusercontent.com/spacchetti/spacchetti/20190131/src/packages.dhall sha256:f6caac8189158d4d7305d5666553f307eeec3c281c002cb602a4e207e4bad939
 
 let overrides = {=}
 


### PR DESCRIPTION
This PR adds the command `spago spacchetti-upgrade`, to upgrade your package set to the latest release if the upstream is Spacchetti (fix #73).

Running it would look something like this:
```bash
$ spago spacchetti-upgrade
Found the most recent tag for "spacchetti": 20190131
Trying to read "packages.dhall"
Package-set upgraded to latest tag "20190131"
Fetching the new one and generating hashes.. (this might take some time)
Done. Updating the local package-set file..
```

This also fixes #39, as CI will now fail if our `packages.dhall` template is not on the latest version of spacchetti. Excerpt from Travis log in case of failure:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/5480361/52162215-30343f80-26d9-11e9-82eb-e94b8631c678.png">
