### PR TITLE
Fix #88: implement handling of local packages in the package-set

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,20 +187,63 @@ $ spago list-packages
 
 #### Adding and overriding dependencies
 
-Let's say I'm a user of the `react-basic` package. Now, let's say I stumble upon a bug
-in there, but thankfully I figure how to fix it. So I fork it, add my fix, and push
-to my fork.  
-Now if I want to use this fork in the current project, how can I tell `spago` to do it?
+Let's say I'm a user of the `simple-json` package. Now, let's say I stumble upon a bug
+in there, but thankfully I figure how to fix it. So I clone it locally and add my fix.  
+Now if I want to test this version in my current project, how can I tell `spago` to do it?
 
-We have a `overrides` record in `packages.dhall` just for that! And in this case it
-might look like this:
+We have a `overrides` record in `packages.dhall` just for that! And in this case we override
+the `repo` key with the local path of the package.  
+It might look like this:
 
 ```haskell
 let overrides =
-      { react-basic =
-            upstream.react-basic
+      { simple-json =
+            upstream.simple-json ⫽ { repo = "../purescript-simple-json" }
+      }
+```
+
+Note that if we `list-packages`, we'll see that it is now included as a local package:
+```bash
+$ spago list-packages
+...
+signal                v10.1.0   Remote "https://github.com/bodil/purescript-signal.git"
+sijidou               v0.1.0    Remote "https://github.com/justinwoo/purescript-sijidou.git"
+simple-json           v4.4.0    Local "../purescript-simple-json"
+simple-json-generics  v0.1.0    Remote "https://github.com/justinwoo/purescript-simple-json-generics.git"
+smolder               v11.0.1   Remote "https://github.com/bodil/purescript-smolder.git"
+...
+```
+
+And since local packages are just included in the build, if we add it to the `dependencies` 
+in `spago.dhall`, and then do `spago install`, it will not be downloaded:
+
+```
+$ spago install
+Installing 42 dependencies.
+...
+Installing "refs"
+Installing "identity"
+Skipping package "simple-json", using local path: "../purescript-simple-json"
+Installing "control"
+Installing "enums"
+...
+```
+
+..but its sources will be just included in the build.
+
+Let's now say that we test that our fix works, and we are ready to Pull Request the fix.  
+So we push our fork and open the PR, but while we wait for the fix to land on the next
+package-set release, we still want to use the fix in our production build.
+
+In this case, we can just change the override to point to some branch of our fork, like this:
+
+
+```haskell
+let overrides =
+      { simple-json =
+            upstream.simple-json
           ⫽ { repo =
-                "https://github.com/my-user/purescript-react-basic.git"
+                "https://github.com/my-user/purescript-simple-json.git"
             , version =
                 "my-branch-with-the-fix"
             }

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -36,7 +36,7 @@ import qualified Turtle                        as T hiding (die, echo)
 import qualified PscPackage
 import           Spago.Config                  (Config (..))
 import qualified Spago.Config                  as Config
-import           Spago.Spacchetti              (Package (..), PackageName (..))
+import           Spago.Spacchetti              (Package (..), PackageName (..), Repo (..))
 import qualified Spago.Templates               as Templates
 import           Spago.Turtle
 
@@ -77,16 +77,27 @@ initProject force = do
 
 
 -- | Returns the dir path for a given package
+--   If the package is from a remote git repo, return the .spago folder in which we cloned
+--   Otherwise return the local folder
 getPackageDir :: (PackageName, Package) -> Text
-getPackageDir (PackageName{..}, Package{..})
+getPackageDir (PackageName{..}, Package{ repo = Remote _, ..})
   = spagoDir <> packageName <> "/" <> version
+getPackageDir (_, Package{ repo = Local path })
+  = path
 
 getGlobs :: [(PackageName, Package)] -> [Text]
 getGlobs = map (\pair -> getPackageDir pair <> "/src/**/*.purs")
 
 
+-- | If the repo points to a remote git, fetch it in the .spago folder.
+--   If it's a local directory do nothing
 getDep :: (PackageName, Package) -> IO ()
-getDep pair@(PackageName{..}, Package{..} ) = do
+getDep (PackageName package, Package { repo = Local path }) =
+  echo $ "Skipping package "
+      <> surroundQuote package
+      <> ", using local path: "
+      <> surroundQuote path
+getDep pair@(PackageName{..}, Package{ repo = Remote repo, ..} ) = do
   exists <- T.testdir $ T.fromText packageDir
   if exists
     then do
@@ -183,16 +194,27 @@ install maybeLimit = do
 listPackages :: IO ()
 listPackages = do
   config <- Config.ensureConfig
-  traverse_ echo $ getPackageNames config
+  traverse_ echo $ formatPackageNames config
 
   where
-    -- | Get all the package names from the configuration
-    getPackageNames :: Config -> [Text]
-    getPackageNames Config { packages = pkgs } =
-      map toText $ Map.toList pkgs
+    -- | Format all the package names from the configuration
+    formatPackageNames :: Config -> [Text]
+    formatPackageNames Config { packages = pkgs } =
+      let
+        pkgsList = Map.toList pkgs
+        longestName = maximum $ Text.length . packageName . fst <$> pkgsList
+        longestVersion = maximum $ Text.length . version . snd <$> pkgsList
+      in map (toText longestName longestVersion) pkgsList
 
-    toText (PackageName{..},Package{..}) =
-      packageName <> " (" <> version <> ", " <> repo <> ")"
+    toText longestName longestVersion (PackageName{..},Package{..})
+      = leftPad longestName packageName <> " "
+      <> leftPad longestVersion version <> "   "
+      <> Text.pack (show repo)
+
+    leftPad :: Int -> Text -> Text
+    leftPad n s
+      | Text.length s < n  = s <> Text.replicate (n - Text.length s) " "
+      | otherwise = s
 
 
 -- | Get source globs of dependencies listed in `spago.dhall`

--- a/app/Spago/Spacchetti.hs
+++ b/app/Spago/Spacchetti.hs
@@ -3,8 +3,10 @@ module Spago.Spacchetti where
 import           Data.Aeson
 import           Data.Map     (Map)
 import           Data.Text    (Text)
+import qualified Data.Text    as Text
 import qualified Dhall
 import           GHC.Generics (Generic)
+import           Network.URI  (parseURI)
 
 
 -- | Matches the packages definition of Spacchetti Package.dhall/psc-package
@@ -15,7 +17,7 @@ newtype PackageName = PackageName { packageName :: Text }
 -- | A spacchetti package.
 data Package = Package
   { dependencies :: [PackageName] -- ^ list of dependency package names
-  , repo         :: Text          -- ^ the git repository
+  , repo         :: Repo          -- ^ the git repository
   , version      :: Text          -- ^ version string (also functions as a git ref)
   }
   deriving (Show, Generic)
@@ -25,3 +27,17 @@ instance FromJSON Package
 
 type Packages = Map PackageName Package
 
+data Repo
+  = Local Text
+  | Remote Text
+  deriving (Show, Generic)
+
+instance ToJSON Repo
+instance FromJSON Repo
+
+instance Dhall.Interpret Repo where
+  autoWith _ = makeRepo <$> Dhall.strictText
+    where
+      makeRepo path = case parseURI $ Text.unpack path of
+        Just _uri -> Remote path
+        Nothing   -> Local path

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
 - async-pool
 - process
 - template-haskell
+- network-uri
 
 executables:
   spago:


### PR DESCRIPTION
Implements support for local packages, as described in https://github.com/spacchetti/spago/issues/88#issue-403519960

Basically we now try to distinguish if "URL"s in the package-set are referring to remote repos, or local filesystem path. In the latter case instead of trying to clone them, we just include their sources in the build (if they are listed as a dependency ofc). This basically mirrors the behaviour of `stack`.

Practical example: let's say I find a bug in simple-json. I manage to fix it locally, but I also want to see if the fix works for my project.

Since simple-json is already in the package-set, I can add the local package to the overrides in `packages.dhall`:
```haskell
...

let overrides = { simple-json = upstream.simple-json // { repo = "../purescript-simple-json" } }

...
```

Note that if I `list-packages`, it is correctly listed as a local package:
```
$ spago list-packages
...
signal                v10.1.0   Remote "https://github.com/bodil/purescript-signal.git"
sijidou               v0.1.0    Remote "https://github.com/justinwoo/purescript-sijidou.git"
simple-json           v4.4.0    Local "../purescript-simple-json"
simple-json-generics  v0.1.0    Remote "https://github.com/justinwoo/purescript-simple-json-generics.git"
smolder               v11.0.1   Remote "https://github.com/bodil/purescript-smolder.git"
...
```

After adding it to the `dependencies` in `spago.dhall`, if I do `spago install`, it will not download it, but only its dependencies:
```
$ spago install
Installing 42 dependencies.
...
Installing "distributive"
Installing "refs"
Installing "identity"
Skipping package "simple-json", using local path: "../purescript-simple-json"
Installing "control"
Installing "enums"
Installing "st"
...
```
