### PR TITLE
NPM name change: purescript-spago → spago

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ infrastructure and tooling, as [`psc-package`][psc-package], [`pulp`][pulp] and
 > Right, so how can I get this thing?
 
 The recommended installation methods are:
-- `npm install -g purescript-spago` (Linux and macOS only - see the latest releases on npm
+- `npm install -g spago` (Linux and macOS only - see the latest releases on npm
   [here][spago-npm])
 - Download the binary from the [latest GitHub release][spago-latest-release]
 - Compile from source by cloning this repo and running `stack install`
@@ -574,7 +574,7 @@ We have two commands for it:
 [purp]: https://github.com/justinwoo/purp
 [parcel]: https://parceljs.org
 [purescript]: https://github.com/purescript/purescript
-[spago-npm]: https://www.npmjs.com/package/purescript-spago
+[spago-npm]: https://www.npmjs.com/package/spago
 [spago-latest-release]: https://github.com/spacchetti/spago/releases/latest
 [spago-issues]: https://github.com/spacchetti/spacchetti-cli/issues
 [affresco]: https://github.com/KSF-Media/affresco/tree/4b430b48059701a544dfb65b2ade07ef9f36328a

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,15 +1,15 @@
-# purescript-spago
+# spago
 
 A simple distribution of [spago](https://github.com/spacchetti/spago) using npm.
 
-[Find it on npm here](http://npmjs.com/package/purescript-spago).
+[Find it on npm here](http://npmjs.com/package/spago).
 
 ## Installation
 
 You can install this into your project dependencies:
 
 ```
-npm install -S purescript-spago
+npm install -S spago
 ```
 
 ## CLI
@@ -17,5 +17,5 @@ npm install -S purescript-spago
 You can also install this globally:
 
 ```
-npm install -g purescript-spago
+npm install -g spago
 ```

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "purescript-spago",
+  "name": "spago",
   "version": "NPM_VERSION",
   "description": "🍝 PureScript package manager and build tool powered by Dhall and Spacchetti package-sets",
   "homepage": "https://github.com/spacchetti/spago",

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.2-20190210/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.2-20190221/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.2-20190210/src/packages.dhall sha256:1bee3f7608ca0f87a88b4b8807cb6722ab9ce3386b68325fbfa71d7211c1cf51
+      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.2-20190221/src/packages.dhall sha256:17410a9b306ed2b62e940fa71ecb567a4a8a9bbce4188f148b1fc9cb23bdafe2
 
 let overrides = {=}
 


### PR DESCRIPTION
Instead of publishing both automatically (as detailed in #44), let's just rename this one, and then `npm deprecate purescript-spago` once the `0.7.0` is published.