### PR TITLE
Format Dhall project files in ASCII

### DIFF
--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -117,7 +117,8 @@ makeConfig force = do
     hasSpagoDhall <- T.testfile path
     T.when hasSpagoDhall $ die $ Messages.foundExistingProject pathText
   T.writeTextFile path Templates.spagoDhall
-  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack pathText)
+  Dhall.Format.format
+    (Dhall.Format.Format Dhall.Pretty.ASCII $ Dhall.Format.Modify (Just $ Text.unpack pathText))
 
   -- We try to find an existing psc-package config, and we migrate the existing
   -- content if we found one, otherwise we copy the default template

--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -15,15 +15,12 @@ import qualified Data.Map                  as Map
 import           Data.Maybe                (mapMaybe)
 import qualified Data.Sequence             as Seq
 import           Data.Text                 (Text)
-import qualified Data.Text                 as Text
 import qualified Data.Text.Encoding        as Text
 import           Data.Text.Prettyprint.Doc (Pretty)
 import           Data.Typeable             (Typeable)
-import qualified Dhall.Format
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Parser              as Parser
-import qualified Dhall.Pretty
 import           Dhall.TypeCheck           (X)
 import qualified Dhall.TypeCheck
 import           GHC.Generics              (Generic)
@@ -117,8 +114,7 @@ makeConfig force = do
     hasSpagoDhall <- T.testfile path
     T.when hasSpagoDhall $ die $ Messages.foundExistingProject pathText
   T.writeTextFile path Templates.spagoDhall
-  Dhall.Format.format
-    (Dhall.Format.Format Dhall.Pretty.ASCII $ Dhall.Format.Modify (Just $ Text.unpack pathText))
+  Dhall.format pathText
 
   -- We try to find an existing psc-package config, and we migrate the existing
   -- content if we found one, otherwise we copy the default template
@@ -184,7 +180,9 @@ withConfigAST transform = do
   resolvedExpr <- Dhall.Import.load expr
   case Dhall.TypeCheck.typeOf resolvedExpr of
     Left  err -> throwIO err
-    Right _   -> T.writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
+    Right _   -> do
+      T.writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
+      Dhall.format pathText
 
   where
     toPkgsList

--- a/app/Spago/Dhall.hs
+++ b/app/Spago/Dhall.hs
@@ -12,12 +12,19 @@ import qualified Data.Text.Prettyprint.Doc.Render.Text as PrettyText
 import           Data.Typeable                         (Typeable)
 import           Dhall
 import           Dhall.Core                            as Dhall hiding (Type, pretty)
+import qualified Dhall.Format
 import qualified Dhall.Map
 import qualified Dhall.Parser                          as Parser
+import qualified Dhall.Pretty
 import           Dhall.TypeCheck                       (X, typeOf)
 
-
 type DhallExpr a = Dhall.Expr Parser.Src a
+
+
+-- | Format a Dhall file in ASCII
+format :: Text -> IO ()
+format pathText = Dhall.Format.format
+  (Dhall.Format.Format Dhall.Pretty.ASCII $ Dhall.Format.Modify (Just $ Text.unpack pathText))
 
 
 -- | Prettyprint a Dhall expression
@@ -82,8 +89,8 @@ coerceToType typ expr = do
   let annot = Dhall.Annot expr $ Dhall.expected typ
   let checkedType = typeOf annot
   case (Dhall.extract typ $ Dhall.normalize annot, checkedType) of
-    (Just x, Right _)  -> Right x
-    _ -> Left $ WrongType typ expr
+    (Just x, Right _) -> Right x
+    _                 -> Left $ WrongType typ expr
 
 
 -- | Spago configuration cannot be read

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -20,11 +20,9 @@ import qualified Data.Text          as Text
 import qualified Data.Versions      as Version
 import qualified Dhall
 import           Dhall.Binary       (defaultStandardVersion)
-import qualified Dhall.Format       as Dhall.Format
 import qualified Dhall.Freeze
 import qualified Dhall.Import
 import qualified Dhall.Parser       as Parser
-import qualified Dhall.Pretty       as Dhall.Pretty
 import qualified Dhall.TypeCheck
 import           GHC.Generics       (Generic)
 import qualified GitHub
@@ -91,8 +89,7 @@ makePackageSetFile force = do
     hasPackagesDhall <- T.testfile path
     T.when hasPackagesDhall $ die $ Messages.foundExistingProject pathText
   T.writeTextFile path Templates.packagesDhall
-  Dhall.Format.format
-    (Dhall.Format.Format Dhall.Pretty.ASCII $ Dhall.Format.Modify (Just $ Text.unpack pathText))
+  Dhall.format pathText
 
 
 -- | Freeze the package-set imports so they can be cached
@@ -162,8 +159,8 @@ withPackageSetAST readOnly transform = do
     (_, ReadOnly)     -> pure ()
     (_, ReadAndWrite) -> do
       echo "Done. Updating the local package-set file.."
-      T.writeTextFile path
-        $ Dhall.prettyWithHeader header expr <> "\n"
+      T.writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
+      Dhall.format pathText
 
 
 -- | Tries to upgrade the Package-Sets release of the local package set.

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -91,7 +91,8 @@ makePackageSetFile force = do
     hasPackagesDhall <- T.testfile path
     T.when hasPackagesDhall $ die $ Messages.foundExistingProject pathText
   T.writeTextFile path Templates.packagesDhall
-  Dhall.Format.format Dhall.Pretty.Unicode (Just $ Text.unpack pathText)
+  Dhall.Format.format
+    (Dhall.Format.Format Dhall.Pretty.ASCII $ Dhall.Format.Modify (Just $ Text.unpack pathText))
 
 
 -- | Freeze the package-set imports so they can be cached

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,19 +2,13 @@ resolver: lts-12.21
 packages:
 - .
 extra-deps:
-
-# Pinning to a commit due to https://github.com/dhall-lang/dhall-haskell/issues/788
-# and https://github.com/dhall-lang/dhall-haskell/pull/805
-- git: https://github.com/dhall-lang/dhall-haskell
-  commit: 04ec45803dff952a1c4d7850789eea47fe8881b0
-  subdirs:
-  - dhall
-  - dhall-json
+- dhall-1.21.0
+- dhall-json-1.2.7
+- async-pool-0.9.0.2
 - cborg-json-0.2.1.0@sha256:af9137557002ca5308fe80570a9a29398dfb9708423870875223796760689ac3
 - versions-3.5.0
 - dotgen-0.4.2
 - megaparsec-7.0.3
 - repline-0.2.0.0
-- async-pool-0.9.0.2
 - serialise-0.2.1.0
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190306/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190310/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190306/src/packages.dhall sha256:72ccc753e710ee8c4ede112f780ad42e61c1436cd4605cf4aeb84b5005e065d6
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190310/src/packages.dhall sha256:19895bfdb2fffdf7af09afdf3f6e6d917c0a14f9582bedb238b208f195852b66
 
 let overrides = {=}
 

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -37,9 +37,9 @@ The "//" or "⫽" means "merge these two records and
 -------------------------------
 let override =
   { packageName =
-      upstream.packageName ⫽ { updateEntity1 = "new value", updateEntity2 = "new value" }
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
   , packageName =
-      upstream.packageName ⫽ { version = "v4.0.0" }
+      upstream.packageName // { version = "v4.0.0" }
   , packageName =
       upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
   }
@@ -49,9 +49,9 @@ Example:
 -------------------------------
 let overrides =
   { halogen =
-      upstream.halogen ⫽ { version = "master" }
+      upstream.halogen // { version = "master" }
   , halogen-vdom =
-      upstream.halogen-vdom ⫽ { version = "v4.0.0" }
+      upstream.halogen-vdom // { version = "v4.0.0" }
   }
 -------------------------------
 
@@ -109,13 +109,13 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190227/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190306/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190227/src/packages.dhall sha256:eb8ae389eb218f1aad4c20054b8cce6c04a861a567aff72abd9111609178e986
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190306/src/packages.dhall sha256:72ccc753e710ee8c4ede112f780ad42e61c1436cd4605cf4aeb84b5005e065d6
 
 let overrides = {=}
 
 let additions = {=}
 
-in  upstream ⫽ overrides ⫽ additions
+in  upstream // overrides // additions


### PR DESCRIPTION
This PR switches the autoformatting of the project files from Unicode to ASCII, as from the [Dhall survey results](https://ferrai.io/2019/dhall-survey-review/) it emerges that ASCII encoding could be more user-friendly
