### PR TITLE
Add first implementation of the `spago docs` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,17 @@ E.g. the following opens a repl on `localhost:3200`:
 $ spago repl -- --port 3200
 ```
 
+### Documentation
+
+To build documentation for your project and its dependencies (i.e. a "project-local
+[Pursuit][pursuit]"), you can use the `docs` command:
+```bash
+$ spago docs
+```
+
+This will generate all the documentation in the `./generated-docs` folder of your project.
+You might then want to open the `index.html` file in there.
+
 ## FAQ
 
 #### Hey wait we have a perfectly functional `pulp` right?
@@ -555,21 +566,22 @@ We have two commands for it:
   echo wrote packages.json to $TARGET
   ```
 
-[package-sets]: https://github.com/purescript/package-sets
-[dhall]: https://github.com/dhall-lang/dhall-lang
-[travis-spago]: https://travis-ci.com/spacchetti/spago
-[cargo]: https://github.com/rust-lang/cargo
-[stack]: https://github.com/commercialhaskell/stack
-[psc-package]: https://github.com/purescript/psc-package
 [pulp]: https://github.com/purescript-contrib/pulp
 [purp]: https://github.com/justinwoo/purp
-[parcel]: https://parceljs.org
-[purescript]: https://github.com/purescript/purescript
-[spago-npm]: https://www.npmjs.com/package/spago
-[spago-latest-release]: https://github.com/spacchetti/spago/releases/latest
-[spago-issues]: https://github.com/spacchetti/spago/issues
-[affresco]: https://github.com/KSF-Media/affresco/tree/4b430b48059701a544dfb65b2ade07ef9f36328a
-[todomvc]: https://github.com/f-f/purescript-react-basic-todomvc
+[dhall]: https://github.com/dhall-lang/dhall-lang
+[cargo]: https://github.com/rust-lang/cargo
+[stack]: https://github.com/commercialhaskell/stack
 [purec]: https://github.com/pure-c/purec
+[parcel]: https://parceljs.org
 [purerl]: https://github.com/purerl/purescript
+[pursuit]: https://pursuit.purescript.org/
+[todomvc]: https://github.com/f-f/purescript-react-basic-todomvc
+[affresco]: https://github.com/KSF-Media/affresco/tree/4b430b48059701a544dfb65b2ade07ef9f36328a
+[spago-npm]: https://www.npmjs.com/package/spago
+[purescript]: https://github.com/purescript/purescript
+[psc-package]: https://github.com/purescript/psc-package
+[package-sets]: https://github.com/purescript/package-sets
+[travis-spago]: https://travis-ci.com/spacchetti/spago
+[spago-issues]: https://github.com/spacchetti/spago/issues
 [dhall-hash-safety]: https://github.com/dhall-lang/dhall-lang/wiki/Safety-guarantees#code-injection
+[spago-latest-release]: https://github.com/spacchetti/spago/releases/latest

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,6 +32,9 @@ data Command
   -- | Start a REPL.
   | Repl [SourcePath] [ExtraArg]
 
+  -- | Generate documentation for the project and its dependencies
+  | Docs [SourcePath]
+
   -- | Build the project paths src/ and test/
   --   plus the specified source paths
   | Build (Maybe Int) [SourcePath] [ExtraArg]
@@ -95,6 +98,7 @@ parser
   T.<|> verifySet
   T.<|> build
   T.<|> repl
+  T.<|> docs
   T.<|> test
   T.<|> bundle
   T.<|> makeModule
@@ -164,6 +168,10 @@ parser
       = T.subcommand "repl" "Start a REPL"
       $ Repl <$> sourcePaths <*> passthroughArgs
 
+    docs
+      = T.subcommand "docs" "Generate docs for the project and its dependencies"
+      $ Docs <$> sourcePaths
+
     test
       = T.subcommand "test" "Test the project with some module, default Test.Main"
       $ Test <$> mainModule <*> limitJobs <*> sourcePaths <*> passthroughArgs
@@ -215,6 +223,7 @@ main = do
     Repl paths pursArgs                   -> Spago.Build.repl paths pursArgs
     Bundle modName tPath                  -> Spago.Build.bundle WithMain modName tPath
     MakeModule modName tPath              -> Spago.Build.makeModule modName tPath
+    Docs sourcePaths                      -> Spago.Build.docs sourcePaths
     Version                               -> printVersion
     PscPackageLocalSetup force            -> PscPackage.localSetup force
     PscPackageInsDhall                    -> PscPackage.insDhall

--- a/app/Spago/Build.hs
+++ b/app/Spago/Build.hs
@@ -4,6 +4,7 @@ module Spago.Build
   , repl
   , bundle
   , makeModule
+  , docs
   , Purs.ExtraArg (..)
   , Purs.ModuleName (..)
   , Purs.SourcePath (..)
@@ -89,3 +90,12 @@ makeModule maybeModuleName maybeTargetPath = do
     >>= \case
       Right _ -> echo $ "Make module succeeded and output file to " <> Purs.unTargetPath targetPath
       Left (n :: SomeException) -> die $ "Make module failed: " <> T.repr n
+
+
+-- | Generate docs for the `sourcePaths`
+docs :: [Purs.SourcePath] -> IO ()
+docs sourcePaths = do
+  config <- Config.ensureConfig
+  deps <- Packages.getProjectDeps config
+  echo "Generating documentation for the project. This might take a while.."
+  Purs.docs $ defaultSourcePaths <> Packages.getGlobs deps <> sourcePaths

--- a/app/Spago/Purs.hs
+++ b/app/Spago/Purs.hs
@@ -56,6 +56,15 @@ bundle withMain (ModuleName moduleName) (TargetPath targetPath) = do
     ("Bundle failed.")
 
 
+docs :: [SourcePath] -> IO ()
+docs sourcePaths = do
+  let
+    paths = Text.intercalate " " $ Messages.surroundQuote <$> map unSourcePath sourcePaths
+    cmd = "purs docs " <> paths <> " --format html"
+  runWithOutput cmd
+    ("Docs generated. Index is at " <> Messages.surroundQuote "./generated-docs/index.html")
+    "Docs generation failed."
+
 version :: IO (Maybe Version.SemVer)
 version = do
   fullVersionText <- T.shellStrict "purs --version" T.empty >>= \case


### PR DESCRIPTION
This implements the first part of #89. It will generate documentation for the project files and its dependencies.

Example of running it:

```
$ spago docs --path "packages/*/src/**/*.purs" --path "apps/*/src/**/*.purs"
Generating documentation for the project. This might take a while..
Docs generated. Index is at "./generated-docs/index.html"
```

