### PR TITLE
Always ensure that the package-set has a hash on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,29 +349,17 @@ Done. Updating the local package-set file..
 
 #### Caching the Package Set
 
-It is important to have the hashes set in your `packages.dhall`, like this:
-
-```haskell
-...
-
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.2-20190210/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
-let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.2-20190210/src/packages.dhall sha256:1bee3f7608ca0f87a88b4b8807cb6722ab9ce3386b68325fbfa71d7211c1cf51
-
-...
-```
-
-The reason why it's so important is that (apart from [the safety guarantees][dhall-hash-safety])
-when your imports are protected by a hash they will be cached, considerably speeding up all
-the config-related operations.
-
-You can freeze the imports in your package set by running:
+If you encounter any issues with the hashes for the package-set (e.g. the hash is not deemed
+correct by `spago`), then you can have the hashes recomputed by running the `freeze` command:
 
 ```bash
 $ spago freeze
 ```
+
+However, this is a pretty rare situation and in principle it should not happen, and when
+it happens it might not be secure to run the above command.  
+To understand all the implications of this I'd invite you to read about
+[the safety guarantees][dhall-hash-safety] that Dhall offers.
 
 ### Building, bundling and testing a project
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -181,7 +181,7 @@ parser
       $ pure PackageSetUpgrade
 
     freeze
-      = T.subcommand "freeze" "Add hashes to the package-set, so it will be cached"
+      = T.subcommand "freeze" "Recompute the hashes for the package-set"
       $ pure Freeze
 
     version

--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -32,6 +32,7 @@ import qualified Turtle                    as T hiding (die, echo)
 import qualified Spago.Dhall               as Dhall
 import qualified Spago.Messages            as Messages
 import           Spago.PackageSet          (Package, PackageName (..), PackageSet)
+import qualified Spago.PackageSet          as PackageSet
 import qualified Spago.PscPackage          as PscPackage
 import qualified Spago.Templates           as Templates
 import           Spago.Turtle
@@ -103,6 +104,7 @@ ensureConfig :: IO Config
 ensureConfig = do
   exists <- T.testfile path
   T.unless exists $ makeConfig False
+  PackageSet.ensureFrozen
   configText <- T.readTextFile path
   try (parseConfig configText) >>= \case
     Right config -> pure config


### PR DESCRIPTION
Until now, the responsibility for freezing the package-set import was on the user.

Since not having a hash on that import severely degrades UX and has security implications, `spago` will now always check that the hash is there, and compute it if it's not.