### PR TITLE
Display suggestion message for dependencies with 'purescript-' prefix

### DIFF
--- a/app/Spago/Packages.hs
+++ b/app/Spago/Packages.hs
@@ -249,7 +249,7 @@ install maybeLimit newPackages = do
   -- Also skip the write if there are no new packages to be written
   case newPackages of
     []         -> pure ()
-    additional -> Config.addDependencies newConfig additional
+    additional -> Config.addDependencies config additional
 
   fetchPackages maybeLimit deps
 

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190310/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190312/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190310/src/packages.dhall sha256:19895bfdb2fffdf7af09afdf3f6e6d917c0a14f9582bedb238b208f195852b66
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190312/src/packages.dhall sha256:379a4e0b19b1c1977d053d6cdd9403c579014f2cbdeab8b72700a1ae438b6897
 
 let overrides = {=}
 

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -88,7 +88,7 @@ expect_success(
 os.rename('spago.dhall', 'spago-install-success.dhall')
 check_fixture('spago-install-success.dhall')
 
-expect_success(
+expect_failure(
     ['spago', 'install', 'foobar'],
     "Spago should not add dependencies that are not in the package set"
 )


### PR DESCRIPTION
Fix #129 

Example:
```
$ spago install purescript-bifunctors
spago: Package `purescript-bifunctors` does not exist in package set, but `bifunctors` does, did you mean that instead?
```
