### PR TITLE
Don't create a configuration automatically if not found

### DIFF
--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -100,7 +100,8 @@ parseConfig dhallText = do
 ensureConfig :: IO Config
 ensureConfig = do
   exists <- T.testfile path
-  T.unless exists $ makeConfig False
+  T.unless exists $ do
+    die $ Messages.cannotFindConfig
   PackageSet.ensureFrozen
   configText <- T.readTextFile path
   try (parseConfig configText) >>= \case

--- a/app/Spago/Messages.hs
+++ b/app/Spago/Messages.hs
@@ -4,6 +4,14 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 
 
+cannotFindConfig :: Text
+cannotFindConfig = makeMessage
+  [ "There's no " <> surroundQuote "spago.dhall" <> "in your current location."
+  , ""
+  , "If you already have a spago project you might be in the wrong subdirectory,"
+  , "otherwise you might want to run `spago init` to initialize a new project."
+  ]
+
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage
   [ "Found " <> pathText <> ": it looks like there's already a project here."

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -78,12 +78,12 @@ run_for(0.5, ['spago', 'install', '-j', '3'])
 time.sleep(1)
 
 expect_success(
-    ['spago', 'install'],
+    ['spago', 'install', '-j', '10'],
     "Subsequent installs should succeed anyways"
 )
 
 expect_success(
-    ['spago', 'install', 'simple-json', 'foreign'],
+    ['spago', 'install', '-j', '10', 'simple-json', 'foreign'],
     "Spago should be able to add dependencies"
 )
 os.rename('spago.dhall', 'spago-install-success.dhall')

--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -3,6 +3,7 @@
 import os
 import json
 import time
+import shutil
 from utils import expect_success, expect_failure, fail, run_for, check_fixture
 
 
@@ -51,7 +52,7 @@ expect_success(
     ['spago', 'init', '-f'],
     "Spago should import config from psc-package"
 )
-os.rename('spago.dhall', 'spago-psc-success.dhall')
+shutil.copy2('spago.dhall', 'spago-psc-success.dhall')
 check_fixture('spago-psc-success.dhall')
 
 
@@ -63,7 +64,7 @@ expect_success(
     ['spago', 'init', '-f'],
     "Spago should not import dependencies that are not in the package-set"
 )
-os.rename('spago.dhall', 'spago-psc-failure.dhall')
+shutil.copy2('spago.dhall', 'spago-psc-failure.dhall')
 check_fixture('spago-psc-failure.dhall')
 
 
@@ -77,22 +78,28 @@ run_for(0.5, ['spago', 'install', '-j', '3'])
 time.sleep(1)
 
 expect_success(
-    ['spago', 'install', '-j', '10'],
+    ['spago', 'install'],
     "Subsequent installs should succeed anyways"
 )
 
 expect_success(
-    ['spago', 'install', '-j', '10', 'simple-json', 'foreign'],
+    ['spago', 'install', 'simple-json', 'foreign'],
     "Spago should be able to add dependencies"
 )
 os.rename('spago.dhall', 'spago-install-success.dhall')
 check_fixture('spago-install-success.dhall')
 
+
+expect_success(
+    ['spago', 'init', '-f'],
+    "Spago should always succeed in doing init with force"
+)
+
 expect_failure(
     ['spago', 'install', 'foobar'],
     "Spago should not add dependencies that are not in the package set"
 )
-os.rename('spago.dhall', 'spago-install-failure.dhall')
+shutil.copy2('spago.dhall', 'spago-install-failure.dhall')
 check_fixture('spago-install-failure.dhall')
 
 


### PR DESCRIPTION
Example of running spago in a directory where there's no configs:

```bash
$ spago build
spago: There's no "spago.dhall"in your current location.

If you already have a spago project you might be in the wrong subdirectory,
otherwise you might want to run `spago init` to initialize a new project.
```
Fix #139

/cc @JamieBallingall
