### PR TITLE
Print the purs commands that spago is calling

### DIFF
--- a/app/Spago/Purs.hs
+++ b/app/Spago/Purs.hs
@@ -81,6 +81,7 @@ version = do
 
 runWithOutput :: T.Text -> T.Text -> T.Text -> IO ()
 runWithOutput command success failure = do
+  echo $ "Running command: `" <> command <> "`"
   T.shell command T.empty >>= \case
     T.ExitSuccess -> echo success
     T.ExitFailure _ -> die failure

--- a/templates/testMain.purs
+++ b/templates/testMain.purs
@@ -5,9 +5,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Console (log)
 
-import Main as Main
-
 main :: Effect Unit
 main = do
-  Main.main
+  log "🍝"
   log "You should add some tests."

--- a/test/fixtures/run-output.txt
+++ b/test/fixtures/run-output.txt
@@ -1,3 +1,4 @@
 🍝
 Installation complete.
+Running command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.

--- a/test/fixtures/test-output.txt
+++ b/test/fixtures/test-output.txt
@@ -1,5 +1,6 @@
 🍝
 You should add some tests.
 Installation complete.
+Running command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
 Tests succeeded.


### PR DESCRIPTION
Example:

```bash
$ spago build
Installing 3 dependencies.
Installing "console"
Installing "prelude"
Installing "effect"
Installation complete.
Running command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
Compiling Type.Data.RowList
...
Compiling Effect.Class.Console
Build succeeded.
```

Fix #143 

/cc @JamieBallingall

This also stops importing the `Main` module from the `Test.Main` module, in case `spago init` doesn't copy them both (/cc @JordanMartinez)
