### PR TITLE
Fix watch flag in commands other than 'build'

### DIFF
--- a/test/spago-test.py
+++ b/test/spago-test.py
@@ -150,8 +150,8 @@ expect_success(
 
 
 ## spago bundle
-shutil.rmtree("./output") ## Remove output to ensure bundle builds as well as bundles
 
+shutil.rmtree("./output") ## Remove output to ensure bundle builds as well as bundles
 expect_success(
     ['spago', 'bundle', '--to', 'bundle.js'],
     "Spago should bundle successfully"
@@ -163,10 +163,12 @@ check_fixture('bundle.js')
 
 
 ## spago make-module
-shutil.rmtree("./output") ## Remove output to ensure bundle builds as well as bundles
 
+# Now we don't remove the output folder, but we pass the `--no-build`
+# flag to skip rebuilding (i.e. we are counting on the previous command to
+# have built stuff for us)
 expect_success(
-    ['spago', 'make-module', '--to', 'module.js'],
+    ['spago', 'make-module', '--to', 'module.js', '--no-build'],
     "Spago should successfully make a module"
 )
 


### PR DESCRIPTION
With the recent changes we added more "build" actions inside other commands, which implies also accepting `--watch` in these other commands (expected behaviour: on file change rerun the command that is being watched).

However, the watch was only piped to the `build` command, so only the build part would be rerun on change. This fixes that by running the whole action on file change instead.