### PR TITLE
Fix installation via Yarn - issue #157

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -7,10 +7,9 @@
     "type": "git",
     "url": "https://github.com/spacchetti/spago.git"
   },
-  "main": "index.js",
   "files": [
     "install.js",
-    "spago"
+    "spago.exe"
   ],
   "scripts": {
     "preinstall": "node ./install.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,10 +7,6 @@
     "type": "git",
     "url": "https://github.com/spacchetti/spago.git"
   },
-  "files": [
-    "install.js",
-    "spago.exe"
-  ],
   "scripts": {
     "preinstall": "node ./install.js"
   },

--- a/npm/spago.exe
+++ b/npm/spago.exe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "This is a stub that will be replaced on install. \

--- a/npm/spago.exe
+++ b/npm/spago.exe
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "This is a stub that will be replaced on install. \
+It is needed to workaround https://github.com/yarnpkg/yarn/issues/3421"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                spago
-version:             0.7.4.0
+version:             0.7.4.5
 github:              "spacchetti/spago"
 license:             BSD3
 author:              "Justin Woo, Fabrizio Ferrai"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                spago
-version:             0.7.4.5
+version:             0.7.5.0
 github:              "spacchetti/spago"
 license:             BSD3
 author:              "Justin Woo, Fabrizio Ferrai"


### PR DESCRIPTION
I also removed the `main` key in `package.json` because it seemed to be bogus (there is no `index.js`), and renamed `spago` to `spago.exe` in `files`, to match the actual file name.

PR checklist:
- [ ] Added a test for the contribution (if applicable)
- [X] Updated the version number [in `package.yaml`](https://github.com/spacchetti/spago/blob/master/package.yaml#L2) according to SemVer (`0.x.y.z`, `x` changes on breaking changes, `y` on additions, `z` on patches)
- [ ] Added some example of the new feature to the `README`

(I didn't do any of the PR checklist stuff - do I need to for this change?)