### PR TITLE
Better handling of Dhall AST

### DIFF
--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -7,14 +7,12 @@ module Spago.Config
 
 import           Spago.Prelude
 
-import qualified Data.List          as List
 import qualified Data.Map           as Map
 import qualified Data.Sequence      as Seq
+import qualified Data.Set           as Set
 import qualified Data.Text.Encoding as Text
-import qualified Dhall.Import
+import qualified Dhall.Core
 import qualified Dhall.Map
-import qualified Dhall.Parser       as Parser
-import           Dhall.TypeCheck    (X)
 import qualified Dhall.TypeCheck
 
 import qualified Spago.Dhall        as Dhall
@@ -44,21 +42,7 @@ instance ToJSON Config
 instance FromJSON Config
 
 
--- | Type to represent the "raw" configuration,
---   which is a configuration which has been parsed from Dhall,
---   but not yet resolved (this is used to manipulate the AST directly)
---
---   Note: not all the values from the configuration are included here.
---
---   Note: this limits the amount of stuff that one can do in Dhall inside
---   the configuration. E.g. you won't be able to have a dependency that
---   is not a string in the list of dependencies of the project.
-data RawConfig = RawConfig
-  { rawName :: Text
-  , rawDeps :: [PackageName]
-  -- TODO: add packages if needed
-  } deriving (Show, Generic)
-
+type Expr = Dhall.DhallExpr Dhall.Import
 
 -- | Tries to read in a Spago Config
 parseConfig :: Spago m => Text -> m Config
@@ -96,7 +80,7 @@ ensureConfig = do
   configText <- readTextFile path
   try (parseConfig configText) >>= \case
     Right config -> pure config
-    Left (err :: Dhall.ReadError X) -> throwM err
+    Left (err :: Dhall.ReadError Dhall.TypeCheck.X) -> throwM err
 
 
 -- | Copies over `spago.dhall` to set up a Spago project.
@@ -119,82 +103,72 @@ makeConfig force = do
       Left err -> echo $ Messages.failedToReadPscFile err
       Right pscConfig -> do
         echo "Found a \"psc-package.json\" file, migrating to a new Spago config.."
-        -- update the project name
-        withConfigAST $ \config -> config { rawName = PscPackage.name pscConfig }
+        withConfigAST (pure . updateName (PscPackage.name pscConfig))
         -- try to update the dependencies (will fail if not found in package set)
         let pscPackages = map PackageName $ PscPackage.depends pscConfig
         config <- ensureConfig
-        addDependencies config pscPackages
+        withConfigAST (addRawDeps config pscPackages)
 
 
--- | Takes a function that manipulates the Dhall AST of the Config,
---   and tries to run it on the current config.
---   If it succeeds, it writes back to file the result returned.
---   Note: it will pass in the parsed AST, not the resolved one (so
---   e.g. imports will still be in the tree). If you need the resolved
---   one, use `ensureConfig`.
-withConfigAST :: Spago m => (RawConfig -> RawConfig) -> m ()
-withConfigAST transform = do
-  -- get a workable configuration
-  exists <- testfile path
-  unless exists $ makeConfig False
-  configText <- readTextFile path
+updateName :: Text -> Expr -> Maybe Expr
+updateName newName (Dhall.RecordLit kvs)
+  | Just _name <- Dhall.Map.lookup "name" kvs = Just $ Dhall.RecordLit
+    $ Dhall.Map.insert "name" (Dhall.toTextLit newName) kvs
+updateName _ _ = Nothing
 
-  -- parse the config without resolving imports
-  (header, expr) <- case Parser.exprAndHeaderFromText mempty configText of
-    Left  err -> throwM err
-    Right (header, ast) -> case Dhall.denote ast of
-      -- remove Note constructors, and check if config is a record
-      Dhall.RecordLit ks -> do
-        rawConfig <- pure $ do
-          currentName <- Dhall.requireKey ks "name" Dhall.fromTextLit
-          currentDeps <- Dhall.requireKey ks "dependencies" toPkgsList
-          Right $ RawConfig currentName currentDeps
-
-        -- apply the transformation if config is valid
-        RawConfig{..} <- case rawConfig of
-          Right conf -> pure $ transform conf
-          Left err   -> die $ Messages.failedToParseFile pathText err
-
-        -- return the new AST from the new config
-        let
-          mkNewAST "name"         _ = Dhall.toTextLit rawName
-          mkNewAST "dependencies" _ = Dhall.ListLit Nothing
-            $ Seq.fromList
-            $ fmap Dhall.toTextLit
-            $ fmap packageName rawDeps
-          mkNewAST _ v = v
-        pure (header, Dhall.RecordLit $ Dhall.Map.mapWithKey mkNewAST ks)
-
-      e -> throwM $ Dhall.ConfigIsNotRecord e
-
-  -- After modifying the expression, we have to check if it still typechecks
-  -- if it doesn't we don't write to file
-  resolvedExpr <- liftIO $ Dhall.Import.load expr
-  case Dhall.TypeCheck.typeOf resolvedExpr of
-    Left  err -> throwM err
-    Right _   -> do
-      writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
-      Dhall.format pathText
-
+addRawDeps :: Spago m => Config -> [PackageName] -> Expr -> m (Maybe Expr)
+addRawDeps config newPackages (Dhall.RecordLit kvs)
+  | Just (Dhall.ListLit Nothing dependencies) <- Dhall.Map.lookup "dependencies" kvs = do
+      case notInPackageSet of
+        -- If none of the newPackages are outside of the set, add them to existing dependencies
+        []-> do
+          oldPackages <- traverse (throws . Dhall.fromTextLit) dependencies
+          let newDepsExpr
+                = Dhall.ListLit Nothing $ fmap (Dhall.toTextLit . packageName)
+                $ Seq.sort $ nubSeq (Seq.fromList newPackages <> fmap PackageName oldPackages)
+          pure $ Just $ Dhall.RecordLit $ Dhall.Map.insert "dependencies" newDepsExpr kvs
+        pkgs -> do
+          echo $ Messages.failedToAddDeps $ map packageName pkgs
+          pure Nothing
   where
-    toPkgsList
-      :: (Pretty a, Typeable a)
-      => Dhall.Expr Parser.Src a
-      -> Either (Dhall.ReadError a) [PackageName]
-    toPkgsList (Dhall.ListLit _ pkgs) =
-      let
-        texts = fmap Dhall.fromTextLit $ toList pkgs
-      in
-      case (lefts texts) of
-        []  -> Right $ fmap PackageName $ rights texts
-        e:_ -> Left e
-    toPkgsList e = Left $ Dhall.DependenciesIsNotList e
+    notInPackageSet = mapMaybe
+      (\p -> case Map.lookup p (packages config) of
+               Just _  -> Nothing
+               Nothing -> Just p)
+      newPackages
+
+    -- | Code from https://stackoverflow.com/questions/45757839
+    nubSeq :: Ord a => Seq a -> Seq a
+    nubSeq xs = (fmap fst . Seq.filter (uncurry notElem)) (Seq.zip xs seens)
+      where
+        seens = Seq.scanl (flip Set.insert) Set.empty xs
+addRawDeps _ _ _ = pure Nothing
 
 
-addRawDeps :: [PackageName] -> RawConfig -> RawConfig
-addRawDeps newDeps config = config
-  { rawDeps = List.sort $ List.nub (newDeps <> (rawDeps config)) }
+-- | Takes a function that manipulates the Dhall AST of the Config, and tries to run it
+--   on the current config. If it succeeds, it writes back to file the result returned.
+--   Note: it will pass in the parsed AST, not the resolved one (so e.g. imports will
+--   still be in the tree). If you need the resolved one, use `ensureConfig`.
+withConfigAST :: Spago m => (Expr -> m (Maybe Expr)) -> m ()
+withConfigAST transform = do
+  rawConfig <- Dhall.readRawExpr pathText
+  case rawConfig of
+    Nothing -> die Messages.cannotFindConfig
+    Just (header, expr) -> do
+      newExpr <- rewriteMExpr transform expr
+      Dhall.writeRawExpr pathText (header, newExpr)
+  where
+    rewriteMExpr
+      :: Spago m
+      => (Dhall.Expr s Dhall.Import -> m (Maybe (Dhall.Expr s Dhall.Import)))
+      -> Dhall.Expr s Dhall.Import
+      -> m (Dhall.Expr s Dhall.Import)
+    rewriteMExpr rules =
+      rewriteMOf
+        Dhall.subExpressions
+        rules
+      . Dhall.Core.denote
+
 
 -- | Try to add the `newPackages` to the "dependencies" list in the Config.
 --   It will not add any dependency if any of them is not in the package set.
@@ -202,12 +176,4 @@ addRawDeps newDeps config = config
 --   dependencies, and write the Config back to file.
 addDependencies :: Spago m => Config -> [PackageName] -> m ()
 addDependencies config newPackages = do
-  let notInPackageSet = mapMaybe
-        (\p -> case Map.lookup p (packages config) of
-                Just _  -> Nothing
-                Nothing -> Just p)
-        newPackages
-  case notInPackageSet of
-    -- If none of the newPackages are outside of the set, add them to existing dependencies
-    []   -> withConfigAST $ addRawDeps newPackages
-    pkgs -> echo $ Messages.failedToAddDeps $ map packageName pkgs
+  withConfigAST $ addRawDeps config newPackages

--- a/app/Spago/Messages.hs
+++ b/app/Spago/Messages.hs
@@ -13,6 +13,19 @@ cannotFindConfig = makeMessage
   , "otherwise you might want to run `spago init` to initialize a new project."
   ]
 
+cannotFindPackages :: Text
+cannotFindPackages = makeMessage
+  [ "There's no " <> surroundQuote "packages.dhall" <> "in your current location."
+  , ""
+  , "If you already have a spago project you might be in the wrong subdirectory,"
+  , "otherwise you might want to run `spago init` to initialize a new package set file."
+  ]
+
+cannotFindPackagesButItsFine :: Text
+cannotFindPackagesButItsFine = makeMessage
+  [ "WARNING: did not find a " <> surroundQuote "packages.dhall" <> "in your current location, skipping compiler version check"
+  ]
+
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage
   [ "Found " <> pathText <> ": it looks like there's already a project here."
@@ -94,8 +107,7 @@ upgradingPackageSet newTag = makeMessage
 
 freezePackageSet :: Text
 freezePackageSet = makeMessage
-  [ "Generating hashes for the package-set so it will be cached."
-  , "This might take some time..."
+  [ "Generating new hashes for the package set file so it will be cached.. (this might take some time)"
   ]
 
 packageSetVersionWarning :: Text

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -67,6 +67,8 @@ instance Dhall.Interpret Repo where
         Just _uri -> Remote repo
         Nothing   -> Local repo
 
+type Expr = Dhall.DhallExpr Dhall.Import
+
 
 pathText :: Text
 pathText = "packages.dhall"
@@ -86,69 +88,24 @@ makePackageSetFile force = do
   Dhall.format pathText
 
 
-data RawPackageSet = RawPackageSet
-  { mkPackage :: !Dhall.Import
-  , upstream  :: !Dhall.Import
-  -- TODO: add additions and overrides if needed
-  } deriving (Show, Generic)
-
-
-data ReadOnly = ReadOnly | ReadAndWrite
-
-
--- | Takes a function that manipulates the Dhall AST of the PackageSet,
---   and tries to run it on the current packages.dhall
---   If it succeeds, it writes back to file the result returned.
---   Note: it will pass in the parsed AST, not the resolved one (so
---   e.g. imports will still be in the tree). If you need the resolved
---   one, use `ensureConfig`.
-withPackageSetAST
-  :: Spago m
-  => ReadOnly
-  -> (RawPackageSet -> m RawPackageSet)
-  -> m ()
-withPackageSetAST readOnly transform = do
-  -- get a workable configuration
+readRawPackageSet :: Spago m => m (Maybe (Text, Expr))
+readRawPackageSet = do
   exists <- testfile path
-  unless exists $ liftIO $ makePackageSetFile False
-  packageSetText <- readTextFile path
+  if exists
+    then (do
+      packageSetText <- readTextFile path
+      fmap Just $ throws $ Parser.exprAndHeaderFromText mempty packageSetText)
+    else (pure Nothing)
 
-  -- parse the config without resolving imports
-  (header, expr) <- case Parser.exprAndHeaderFromText mempty packageSetText of
-    Left err -> do
-      echo $ Messages.failedToReadFile pathText
-      throwM err
-    Right (comment, ast) -> case Dhall.denote ast of
-      -- remove Note constructors, and match on the `let` shape
-      Dhall.Let
-        (Dhall.Binding "mkPackage" ann1 (Dhall.Embed mkPackageImport)
-          :| (Dhall.Binding "upstream" ann2 (Dhall.Embed upstreamImport)):rest)
-        body
-        -> do
-        -- run the transform on the package set
-        RawPackageSet{..} <- transform $ RawPackageSet mkPackageImport upstreamImport
-        -- rebuild it
-        pure $ (,) comment
-          $ Dhall.Let
-              (Dhall.Binding "mkPackage" ann1 (Dhall.Embed mkPackage)
-                :| (Dhall.Binding "upstream" ann2 (Dhall.Embed upstream)):rest)
-              body
-
-      e -> die
-        $ Messages.failedToParseFile pathText
-        $ Dhall.CannotParsePackageSet e
-
+writeRawPackageSet :: Spago m => (Text, Expr) -> m ()
+writeRawPackageSet (header, expr) = do
   -- After modifying the expression, we have to check if it still typechecks
   -- if it doesn't we don't write to file.
-  -- We also don't write to file if we are supposed to only read.
   resolvedExpr <- liftIO $ Dhall.Import.load expr
-  case (Dhall.TypeCheck.typeOf resolvedExpr, readOnly) of
-    (Left err, _)     -> throwM err
-    (_, ReadOnly)     -> pure ()
-    (_, ReadAndWrite) -> do
-      echo "Done. Updating the local package-set file.."
-      writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
-      liftIO $ Dhall.format pathText
+  throws (Dhall.TypeCheck.typeOf resolvedExpr)
+  echo "Done. Updating the \"packages.dhall\" file.."
+  writeTextFile path $ Dhall.prettyWithHeader header expr <> "\n"
+  liftIO $ Dhall.format pathText
 
 
 -- | Tries to upgrade the Package-Sets release of the local package set.
@@ -165,25 +122,20 @@ upgradePackageSet = do
     Left err -> die $ Messages.failedToReachGitHub err
     Right GitHub.Release{..} -> do
       echo ("Found the most recent tag for \"purescript/package-sets\": " <> surroundQuote releaseTagName)
-      withPackageSetAST ReadAndWrite $ \packagesRaw -> do
-        maybePackages <- pure $ do
-          newMkPackages <- upgradeImport releaseTagName $ mkPackage packagesRaw
-          newUpstream   <- upgradeImport releaseTagName $ upstream packagesRaw
-          pure $ RawPackageSet newMkPackages newUpstream
-        case maybePackages of
-          Left wrongImport ->
-            throwM $ (Dhall.ImportCannotBeUpdated wrongImport :: Dhall.ReadError Dhall.Import)
+      rawPackageSet <- readRawPackageSet
+      case rawPackageSet of
+        Nothing -> die Messages.cannotFindPackages
+        Just (header, expr) -> do
+          let newExpr = fmap (upgradeImports releaseTagName) expr
+          echo $ Messages.upgradingPackageSet releaseTagName
+          writeRawPackageSet (header, newExpr)
           -- If everything is fine, refreeze the imports
-          Right RawPackageSet{..} -> liftIO $ do
-            echo $ Messages.upgradingPackageSet releaseTagName
-            frozenMkPackages <- Dhall.Freeze.freezeImport "." defaultStandardVersion mkPackage
-            frozenUpstream   <- Dhall.Freeze.freezeImport "." defaultStandardVersion upstream
-            pure $ RawPackageSet frozenMkPackages frozenUpstream
+          freeze
   where
     -- | Given an import and a new purescript/package-sets tag,
     --   upgrades the import to the tag and resets the hash
-    upgradeImport :: Text -> Dhall.Import -> Either Dhall.Import Dhall.Import
-    upgradeImport newTag imp@Dhall.Import
+    upgradeImports :: Text -> Dhall.Import -> Dhall.Import
+    upgradeImports newTag imp@(Dhall.Import
       { importHashed = Dhall.ImportHashed
         { importType = Dhall.Remote Dhall.URL
           -- Check if we're dealing with the right repo
@@ -198,7 +150,7 @@ upgradePackageSet = do
         , ..
         }
       , ..
-      } =
+      }) =
       let components = [ "src", newTag, "package-sets", "purescript" ]
           directory = Dhall.Directory{..}
           newPath = Dhall.File{..}
@@ -208,108 +160,109 @@ upgradePackageSet = do
           importHashed = Dhall.ImportHashed { hash = newHash, ..}
           newImport = Dhall.Import{..}
       in case (ghOrg, ghRepo) of
-        ("spacchetti", "spacchetti")   -> Right newImport
-        ("purescript", "package-sets") -> Right newImport
-        _                              -> Left imp
-    upgradeImport _ imp = Left imp
-
-
--- | Given a Dhall.Import, extract the GitHub tag if the upstream is
---   purescript/package-sets or spacchetti
-getPackageSetTag :: Dhall.Import -> Maybe Text
-getPackageSetTag Dhall.Import
-  { importHashed = Dhall.ImportHashed
-    { importType = Dhall.Remote Dhall.URL
-      -- Check if we're dealing with the right repo
-      { authority = "raw.githubusercontent.com"
-      , path = Dhall.File
-        { directory = Dhall.Directory
-          { components = [ "src", tag, ghRepo, ghOrg ]}
-        , ..
-        }
-      , ..
-      }
-    , ..
-    }
-  , ..
-  } = case (ghOrg, ghRepo) of
-        ("spacchetti", "spacchetti")   -> Just tag
-        ("purescript", "package-sets") -> Just tag
-        _                              -> Nothing
-getPackageSetTag _ = Nothing
+        ("spacchetti", "spacchetti")   -> newImport
+        ("purescript", "package-sets") -> newImport
+        _                              -> imp
+    upgradeImports _ imp = imp
 
 
 checkPursIsUpToDate :: Spago m => m ()
 checkPursIsUpToDate = do
-  withPackageSetAST ReadOnly $ \packageSet@RawPackageSet{..} -> do
-    -- Let's talk backwards-compatibility.
-    -- At some point we switched Spacchetti from tagging the PackageSet with
-    -- something like '20180923'  to something like '0.12.2-20190209' instead
-    -- (in order to support this check).
-    -- Now, if people are still using the old tag, we should:
-    -- - warn them to upgrade with `package-set-upgrade`
-    -- - skip this check
-    --
-    -- Update 2019-02-28: we switched from Spacchetti to package-sets, which
-    -- uses a different versioning (with "psc-" in front). We just strip it away
-    case fmap (Text.split (=='-') . Text.replace "psc-" "") (getPackageSetTag upstream) of
-      Just (minPursVersion:_) -> do
-        maybeCompilerVersion <- Purs.version
-        case (maybeCompilerVersion, hush $ Version.semver minPursVersion) of
-          (Just compilerVersion, Just pursVersionFromPackageSet) -> do
-            performCheck compilerVersion pursVersionFromPackageSet
-          _ -> echo "WARNING: unable to parse versions, skipping check.."
-      _ -> echo Messages.packageSetVersionWarning
+  rawPackageSet <- readRawPackageSet
+  case rawPackageSet of
+    Nothing -> echo Messages.cannotFindPackagesButItsFine
+    Just (_header, expr) -> do
+      maybeCompilerVersion <- Purs.version
+      let packageSetTags = foldMap getPackageSetTag expr
 
-    -- We have to return a RawPackageSet, unmodified.
-    -- TODO: refactor so we don't have to return it
-    pure packageSet
+      -- Let's talk backwards-compatibility.
+      -- At some point we switched Spacchetti from tagging the PackageSet with
+      -- something like '20180923'  to something like '0.12.2-20190209' instead
+      -- (in order to support this check).
+      -- Now, if people are still using the old tag, we should:
+      -- - warn them to upgrade with `package-set-upgrade`
+      -- - skip this check
+      --
+      -- Update 2019-02-28: we switched from Spacchetti to package-sets, which
+      -- uses a different versioning (with "psc-" in front). We just strip it away
+      case fmap (Text.split (=='-') . Text.replace "psc-" "") packageSetTags of
+        ((minPursVersion:_):_)
+          | Just compilerVersion <- maybeCompilerVersion
+          , Just pursVersionFromPackageSet <- hush $ Version.semver minPursVersion -> do
+          performCheck compilerVersion pursVersionFromPackageSet
+        _ -> echo "WARNING: unable to parse compiler and package set versions, skipping check.."
 
-    where
-      -- | The check is successful only when the installed compiler is "slightly"
-      --   greater (or equal of course) to the minimum version. E.g. fine cases are:
-      --   - current is 0.12.2 and package-set is on 0.12.1
-      --   - current is 1.4.3 and package-set is on 1.3.4
-      --   Not fine cases are e.g.:
-      --   - current is 0.1.2 and package-set is 0.2.3
-      --   - current is 1.2.3 and package-set is 1.3.4
-      --   - current is 1.2.3 and package-set is 0.2.3
-      performCheck :: Spago m => Version.SemVer -> Version.SemVer -> m ()
-      performCheck actualPursVersion minPursVersion = do
-        let versionList semver = semver ^.. (Version.major <> Version.minor <> Version.patch)
-        case (versionList actualPursVersion, versionList minPursVersion) of
-          ([0, b, c], [0, y, z]) | b == y && c >= z -> pure ()
-          ([a, b, _c], [x, y, _z]) | a /= 0 && a == x && b >= y -> pure ()
-          _ -> die $ Messages.pursVersionMismatch
-                 (Version.prettySemVer actualPursVersion)
-                 (Version.prettySemVer minPursVersion)
+  where
+    -- | The check is successful only when the installed compiler is "slightly"
+    --   greater (or equal of course) to the minimum version. E.g. fine cases are:
+    --   - current is 0.12.2 and package-set is on 0.12.1
+    --   - current is 1.4.3 and package-set is on 1.3.4
+    --   Not fine cases are e.g.:
+    --   - current is 0.1.2 and package-set is 0.2.3
+    --   - current is 1.2.3 and package-set is 1.3.4
+    --   - current is 1.2.3 and package-set is 0.2.3
+    performCheck :: Spago m => Version.SemVer -> Version.SemVer -> m ()
+    performCheck actualPursVersion minPursVersion = do
+      let versionList semver = semver ^.. (Version.major <> Version.minor <> Version.patch)
+      case (versionList actualPursVersion, versionList minPursVersion) of
+        ([0, b, c], [0, y, z]) | b == y && c >= z -> pure ()
+        ([a, b, _c], [x, y, _z]) | a /= 0 && a == x && b >= y -> pure ()
+        _ -> die $ Messages.pursVersionMismatch
+            (Version.prettySemVer actualPursVersion)
+            (Version.prettySemVer minPursVersion)
+
+    -- | Given a Dhall.Import extract the GitHub tag if it's the upstream import, and
+    --   if it points to purescript/package-sets or spacchetti
+    getPackageSetTag :: Dhall.Import -> [Text]
+    getPackageSetTag (Dhall.Import
+      { importHashed = Dhall.ImportHashed
+        { importType = Dhall.Remote Dhall.URL
+          -- Check if we're dealing with the right repo
+          { authority = "raw.githubusercontent.com"
+          , path = Dhall.File
+            { directory = Dhall.Directory
+              { components = [ "src", tag, ghRepo, ghOrg ]}
+            , file = "packages.dhall"
+            }
+          , ..
+          }
+        , ..
+        }
+      , ..
+      }) = case (ghOrg, ghRepo) of
+             ("spacchetti", "spacchetti")   -> [tag]
+             ("purescript", "package-sets") -> [tag]
+             _                              -> []
+    getPackageSetTag _ = []
 
 
--- | Given a Dhall.Import, tell if it's frozen
-isFrozen :: Dhall.Import -> Bool
-isFrozen Dhall.Import
+isRemoteFrozen :: Dhall.Import -> [Bool]
+isRemoteFrozen (Dhall.Import
   { importHashed = Dhall.ImportHashed
-    { hash = Just _someHash
+    { importType = Dhall.Remote _
     , ..
     }
   , ..
-  }        = True
-isFrozen _ = False
+  })             = [isJust hash]
+isRemoteFrozen _ = []
 
 
--- | Freeze the package-set imports so they can be cached
+-- | Freeze the package set remote imports so they will be cached
 freeze :: Spago m => m ()
 freeze = do
   echo Messages.freezePackageSet
-  liftIO $ Dhall.Freeze.freeze (Just $ Text.unpack pathText) False defaultStandardVersion
+  liftIO $ do
+    Dhall.Freeze.freeze (Just $ Text.unpack pathText) False defaultStandardVersion
+    Dhall.format pathText
 
 
--- | Check that the package-set import is correctly setup with hashes, and freeze it if not
+-- | Freeze the file if any of the remote imports are not frozen
 ensureFrozen :: Spago m => m ()
 ensureFrozen = do
-  withPackageSetAST ReadOnly $ \packageSet@RawPackageSet{..} -> do
-    case isFrozen upstream of
-      True  -> pure ()
-      False -> freeze
-
-    pure packageSet
+  rawPackageSet <- readRawPackageSet
+  case rawPackageSet of
+    Nothing -> echo "WARNING: wasn't able to check if your package set file is frozen"
+    Just (_header, expr) -> do
+      let areRemotesFrozen = foldMap isRemoteFrozen expr
+      unless (and areRemotesFrozen) $ do
+        freeze

--- a/app/Spago/Packages.hs
+++ b/app/Spago/Packages.hs
@@ -60,7 +60,7 @@ initProject force = do
   copyIfNotExists ".gitignore" Templates.gitignore
 
   echo "Set up a local Spago project."
-  echo "Try running `spago install`"
+  echo "Try running `spago build`"
 
   where
     whenDirNotExists dir action = do

--- a/app/Spago/Prelude.hs
+++ b/app/Spago/Prelude.hs
@@ -22,7 +22,7 @@ module Spago.Prelude
   , (<|>)
   , (</>)
   , (^..)
-  , rewriteMOf
+  , transformMOf
   , testfile
   , testdir
   , mktree
@@ -53,7 +53,7 @@ module Spago.Prelude
 
 import           Control.Applicative       (empty, many, (<|>))
 import           Control.Lens              ((^..))
-import           Control.Lens.Combinators  (rewriteMOf)
+import           Control.Lens.Combinators  (transformMOf)
 import           Control.Monad             as X
 import           Control.Monad.Catch       as X
 import           Control.Monad.Reader      as X

--- a/app/Spago/Prelude.hs
+++ b/app/Spago/Prelude.hs
@@ -13,6 +13,7 @@ module Spago.Prelude
   , Typeable
   , Text
   , NonEmpty (..)
+  , Seq (..)
   , Map
   , Generic
   , Pretty
@@ -21,6 +22,7 @@ module Spago.Prelude
   , (<|>)
   , (</>)
   , (^..)
+  , rewriteMOf
   , testfile
   , testdir
   , mktree
@@ -50,6 +52,8 @@ module Spago.Prelude
   ) where
 
 import           Control.Applicative       (empty, many, (<|>))
+import           Control.Lens              ((^..))
+import           Control.Lens.Combinators  (rewriteMOf)
 import           Control.Monad             as X
 import           Control.Monad.Catch       as X
 import           Control.Monad.Reader      as X
@@ -59,6 +63,7 @@ import           Data.Foldable             as X
 import           Data.List.NonEmpty        (NonEmpty (..))
 import           Data.Map                  (Map)
 import           Data.Maybe                as X
+import           Data.Sequence             (Seq (..))
 import           Data.Text                 (Text)
 import qualified Data.Text                 as Text
 import           Data.Text.Prettyprint.Doc (Pretty)
@@ -66,7 +71,6 @@ import           Data.Traversable          (for)
 import           Data.Typeable             (Typeable)
 import           GHC.Conc                  (atomically, newTVarIO, readTVar, readTVarIO, writeTVar)
 import           GHC.Generics              (Generic)
-import           Lens.Micro                ((^..))
 import           Prelude                   as X hiding (FilePath)
 import           Safe                      (headMay)
 import           System.FilePath           (isAbsolute, pathSeparator, (</>))

--- a/app/Spago/Prelude.hs
+++ b/app/Spago/Prelude.hs
@@ -3,6 +3,7 @@ module Spago.Prelude
   , echoStr
   , echoDebug
   , die
+  , throws
   , hush
   , withDirectory
   , pathFromText
@@ -113,6 +114,10 @@ echoDebug str = do
 die :: MonadThrow m => Text -> m a
 die reason = throwM $ SpagoError reason
 
+-- | Throw Lefts
+throws :: MonadThrow m => Exception e => Either e a -> m a
+throws (Left  e) = throwM e
+throws (Right a) = pure a
 
 -- | Suppress the 'Left' value of an 'Either'
 hush :: Either a b -> Maybe b

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,7 @@ dependencies:
 - network-uri
 - github
 - versions
-- microlens
+- lens
 - safe
 - fsnotify
 - Glob

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190330/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190403/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190330/src/packages.dhall sha256:cb0cdde5926cfdff5bd17bb2508a85b5eee794088f253f59f884766828ba722c
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.3-20190403/src/packages.dhall sha256:53f95298ca7734c037a0ebfd2ce982c004d8377ebc01cc3387f5a61508c6b8ac
 
 let overrides = {=}
 


### PR DESCRIPTION
Fix #158 
Fix #162 
Fix #163

This PR reworks how the `config.dhall` and `packages.dhall` files are handled when reading their unevaluated form (i.e. as Dhall AST).
A small summary of what's in it:
- move from pattern matching on the shape of the AST to instead traversing the tree and searching for patterns (using e.g. `Control.Lens.Combinators.transformOf`), and this gives us less error conditions and more freedom for the user to edit the config as they wish
- In fact, the shape of `packages.dhall` is now not constrained at all, while `spago.dhall` still needs to be a record containing the `dependencies` key (we need this for `spago install $dep`)
- In case the packages file is not there Spago will not be happy (e.g. it wants to check that the upstream tag is compatible, and wants to check that the packages file is frozen, etc) but continue execution, emitting small 1-line warnings instead of the current 4-line warning
- The only exception to the above is when doing `spago package-set-upgrade`, in which case Spago will error out if the file is not there

/cc @jmackie could you try this out and see if it behaves as you'd expect?