### PR TITLE
Don't fail init if a packages.dhall is already there

### DIFF
--- a/app/Spago/Messages.hs
+++ b/app/Spago/Messages.hs
@@ -28,8 +28,7 @@ cannotFindPackagesButItsFine = makeMessage
 
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage
-  [ "Found " <> pathText <> ": it looks like there's already a project here."
-  , "Run `spago init --force` if you're sure you want to overwrite it."
+  [ "Found a " <> surroundQuote pathText <> " file, skipping copy. Run `spago init --force` if you wish to overwrite it."
   ]
 
 foundExistingDirectory :: Text -> Text

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -78,7 +78,7 @@ makePackageSetFile :: Bool -> IO ()
 makePackageSetFile force = do
   unless force $ do
     hasPackagesDhall <- testfile path
-    when hasPackagesDhall $ die $ Messages.foundExistingProject pathText
+    when hasPackagesDhall $ echo $ Messages.foundExistingProject pathText
   writeTextFile path Templates.packagesDhall
   Dhall.format pathText
 

--- a/app/Spago/Packages.hs
+++ b/app/Spago/Packages.hs
@@ -44,6 +44,8 @@ spagoDir = ".spago/"
 --   - create an example `test` folder (if needed)
 initProject :: Spago m => Bool -> m ()
 initProject force = do
+  echo "Initializing a sample project or migrating an existing one.."
+
   -- packages.dhall and spago.dhall overwrite can be forced
   liftIO $ PackageSet.makePackageSetFile force
   Config.makeConfig force

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -109,10 +109,10 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190427/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190501/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190427/src/packages.dhall sha256:6b17811247e1f825034fa4dacc4b8ec5eddd0e832e0e1579c2ba3b9b2a1c63fe
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.5-20190501/src/packages.dhall sha256:3476d1c5b26c5372cb5baa5e9b9b94a50fc8c09d368f66e411c9176cbf15bdc7
 
 let overrides = {=}
 


### PR DESCRIPTION
Fix #179 

New output of `init` on a project with a `packages.dhall`:

```
Initializing a sample project or migrating an existing one..
Found a "packages.dhall" file, skipping copy. Run `spago init --force` if you wish to overwrite it.
Found a "psc-package.json" file, migrating to a new Spago config..
Done. Updating the "spago.dhall" file..
Found existing directory "src", skipping copy of sample sources
Found existing directory "test", skipping copy of sample sources
Found existing file ".gitignore", not overwriting it
Set up a local Spago project.
Try running `spago build`
```