### PR TITLE
Fix Yarn & NPM shim issues on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `spago-curator` tool to generate metadata from the package set (#202)
 
 Bugfixes:
-- Another attempt to fix NPM and Yarn installations on Windows (#187)
+- Another attempt to fix NPM and Yarn installations on Windows (#215, #187)
 
 ## [0.8.0] - 2019-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `spago-curator` tool to generate metadata from the package set (#202)
 
+Bugfixes:
+- Another attempt to fix NPM and Yarn installations on Windows (#187)
+
 ## [0.8.0] - 2019-05-16
 
 Breaking changes:
@@ -145,4 +148,3 @@ Main changes from the previous "spacchetti-cli" incarnation:
 - Freeze `spacchetti` package-set import in `packages.dhall`, so `dhall` caching works for subsequent executions
 - Move to v4.0.0 of `dhall`
 - Add integration tests for most of the commands (#31, #30)
-

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Other installation methods available:
 **General notes:**
 - The assumption is that you already installed the [PureScript compiler][purescript].
   If not, get it with `npm install -g purescript`, or the recommended method for your OS.
-- You might have issues with `npm` and Docker (e.g. getting the message "This is a stub that will be replaced.." etc)
+- You might have issues with `npm` and Docker (e.g. getting the message "Downloading the spago binary failed.." etc)
   You have two options:
   - either **do not run npm as root**, because it doesn't work well with binaries. Use it as a nonprivileged user.
   - or use `--unsafe-perm`: `npm install -g --unsafe-perm spago` 
@@ -134,9 +134,6 @@ Other installation methods available:
 
 **Notes for NixOS users**: as you might expect, the `npm` installation won't work because it's
 dynamically linked. Use [easy-purescript-nix][spago-nix].
-
-**Notes for Windows users:** if you are installing with `yarn` on Windows, things might not
-work and you want to instead use `npm`. See [this issue][windows-issue-yarn] for details.
 
 
 ## Super quick tutorial

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,17 +5,10 @@
 
 const https = require("follow-redirects").https;
 const tar = require("tar");
-const shell = require("shelljs");
 const version = "PACKAGE_VERSION";
 const platform = { win32: "windows", darwin: "osx" }[process.platform] || "linux";
 
 https.get(
     `https://github.com/spacchetti/spago/releases/download/${version}/${platform}.tar.gz`,
-    res => res.pipe(
-        tar.x({"C": './'}).on("finish", () => {
-            if (shell.test("-f", "./spago")) {
-                shell.mv("./spago", "./spago.exe")
-            }
-        })
-    )
+    res => res.pipe(tar.x({"C": './'}))
 );

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,15 +8,14 @@
     "url": "https://github.com/spacchetti/spago.git"
   },
   "scripts": {
-    "preinstall": "node ./install.js"
+    "postinstall": "node ./install.js"
   },
   "author": "Justin Woo, Fabrizio Ferrai",
   "bin": {
-    "spago": "./spago.exe"
+    "spago": "./spago"
   },
   "dependencies": {
     "follow-redirects": "^1.7.0",
-    "shelljs": "^0.8.3",
     "tar": "^4.4.8"
   },
   "keywords": [

--- a/npm/spago
+++ b/npm/spago
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const cp = require("child_process");
+
+const spago = cp.spawn(__dirname + '/spago.exe', process.argv.slice(2), {stdio: 'inherit'});
+spago.on('error', (err) => {
+    console.log("Downloading the spago binary failed. Please try reinstalling the spago npm package.");
+});

--- a/npm/spago.exe
+++ b/npm/spago.exe
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "This is a stub that will be replaced on install. \
-It is needed to workaround https://github.com/yarnpkg/yarn/issues/3421"


### PR DESCRIPTION
### Description of the change

(Hopefully) a fix for the shim issues on Windows described in https://github.com/spacchetti/spago/issues/187#issuecomment-494029142. Namely:
- Shims created by Yarn are broken because they try to run spago via bash.
- Shims created by NPM for bash don't work because they reference an undefined `$basedir` variable

To fix the NPM issue in particular, instead of having the package try to shim to the spago binary directly, a "2nd-level shim" nodejs script is used. This script then runs the spago binary. Since this shim doesn't
get changed during the package install process, Yarn doesn't get confused either. The script is only used on Windows.

So the result is this:
- The binary declared in the package's `package.json` is simply `spago`.
- A `spago` file is included with the package. This is a nodejs script that simply runs an expected sibling `spago.exe` file.
- On installing the package:
  - (On Windows) Yarn/NPM create their shims to call the `spago` script under nodejs. These have no issues.
  - (On Mac/Linux) A symlink is created to the `spago` file as normal.
- After the package is installed, in a `postinstall` script:
  - (On Windows) the `spago.exe` binary file is downloaded, so the nodejs shim will now work.
  - (On Mac/Linux) The binary file is downloaded, which since it's also named `spago`, simply replaces the javascript file, and the symlinks point to this file instead.

Have manually tested on all combinations of the following on Windows: Cmd, Git-Bash, "Linux" (WSL); NPM and Yarn; global and local package installations.

I guess if this patch proves successful then the note about Yarn in the readme can also be removed.

### PR checklist:

- [ ] (Not sure if this is needed?) Updated the version number [in `package.yaml`](https://github.com/spacchetti/spago/blob/master/package.yaml#L2) according to SemVer (`0.x.y.z`, `x` bumps on breaking changes, `y` on additions, `z` on patches)
- [x] Added the change to the "Unreleased" section of the changelog

Fix #187