### PR TITLE
Fix missing spaces in messages

### DIFF
--- a/app/Spago/Messages.hs
+++ b/app/Spago/Messages.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as Text
 
 cannotFindConfig :: Text
 cannotFindConfig = makeMessage
-  [ "There's no " <> surroundQuote "spago.dhall" <> "in your current location."
+  [ "There's no " <> surroundQuote "spago.dhall" <> " in your current location."
   , ""
   , "If you already have a spago project you might be in the wrong subdirectory,"
   , "otherwise you might want to run `spago init` to initialize a new project."
@@ -15,7 +15,7 @@ cannotFindConfig = makeMessage
 
 cannotFindPackages :: Text
 cannotFindPackages = makeMessage
-  [ "There's no " <> surroundQuote "packages.dhall" <> "in your current location."
+  [ "There's no " <> surroundQuote "packages.dhall" <> " in your current location."
   , ""
   , "If you already have a spago project you might be in the wrong subdirectory,"
   , "otherwise you might want to run `spago init` to initialize a new package set file."
@@ -23,7 +23,7 @@ cannotFindPackages = makeMessage
 
 cannotFindPackagesButItsFine :: Text
 cannotFindPackagesButItsFine = makeMessage
-  [ "WARNING: did not find a " <> surroundQuote "packages.dhall" <> "in your current location, skipping compiler version check"
+  [ "WARNING: did not find a " <> surroundQuote "packages.dhall" <> " in your current location, skipping compiler version check"
   ]
 
 foundExistingProject :: Text -> Text


### PR DESCRIPTION
Just a quick one; 3 messages were missing a space (does this need adding to the changelog?)