### PR TITLE
Fix psc-package-clean and test cleanup on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Fix `spago psc-package-clean` on Windows (#224)
+
+Other improvements:
+- Test suite now works fully on Windows (#224)
+
 ## [0.8.1] - 2019-05-29
 
 New features:

--- a/app/Spago/PscPackage.hs
+++ b/app/Spago/PscPackage.hs
@@ -14,6 +14,7 @@ import qualified Data.Text.Lazy           as LT
 import qualified Data.Text.Lazy.Encoding  as LT
 import qualified Dhall.JSON               as Dhall.JSON
 import           GHC.Generics             (Generic)
+import           System.Directory         (removePathForcibly)
 import qualified Turtle                   as T
 
 import qualified Spago.PackageSet         as PackageSet
@@ -133,6 +134,6 @@ clean = do
   hasDir <- T.testdir pscDir
   if hasDir
     then do
-      T.rmtree pscDir
+      removePathForcibly $ T.encodeString pscDir
       T.echo "Packages cache was cleaned."
     else T.echo "Nothing to clean here."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - choco install -y haskell-stack --version %STACK_VERSION%
   - stack setup > nul
   - choco install purescript
+  - choco install psc-package
 
 cache:
   - C:\sr -> '%STACK_YAML%'
@@ -34,7 +35,7 @@ build_script:
 test_script:
   - set PATH=C:\projects\spago\bin;%PATH%
   - set XDG_CACHE_HOME=C:\cache
-  - stack test --test-arguments=--match=Spago
+  - stack test
 
 artifacts:
   - path: windows.tar.gz

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -6,8 +6,8 @@ import           Prelude             hiding (FilePath)
 import           Test.Hspec          (Spec, around_, beforeAll, describe, it,
                                       shouldBe)
 import           Turtle              (FilePath, cp, mkdir, mv, readTextFile, rm,
-                                      rmtree, testdir, writeTextFile)
-import           Utils               (checkFixture, runFor, shouldBeFailure,
+                                      testdir, writeTextFile)
+import           Utils               (checkFixture, rmtree, runFor, shouldBeFailure,
                                       shouldBeFailureOutput, shouldBeSuccess,
                                       shouldBeSuccessOutput, spago, withCwd)
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,5 +1,6 @@
 module Utils
   ( checkFixture
+  , rmtree
   , runFor
   , shouldBeFailure
   , shouldBeFailureOutput
@@ -12,10 +13,11 @@ module Utils
 import qualified Control.Concurrent as Concurrent
 import qualified Control.Exception  as Exception
 import           Prelude            hiding (FilePath)
+import           System.Directory   (removePathForcibly)
 import qualified System.Process     as Process
 import           Test.Hspec         (shouldBe)
 import           Turtle             (ExitCode (..), FilePath, Text, cd, empty,
-                                     procStrictWithErr, pwd, readTextFile)
+                                     encodeString, procStrictWithErr, pwd, readTextFile)
 
 withCwd :: FilePath -> IO () -> IO ()
 withCwd dir cmd = do
@@ -57,3 +59,6 @@ checkFixture path = do
   actual <- readTextFile path
   expected <- readFixture path
   actual `shouldBe` expected
+
+rmtree :: FilePath -> IO ()
+rmtree = removePathForcibly . encodeString


### PR DESCRIPTION
### Description of the change

Replaces use of `Turtle.rmtree` with `System.Directory.removePathForcibly` to fix the following issues on Windows.

`spago psc-package-clean` (and its test) fail because:
1. Git marks files under its /objects subdirectory as read-only
2. Turtle.rmtree fails to delete files marked as read-only

So `rmtree` fails to remove any folder that's a git repository.

As well as `psc-package-clean`, general test cleanup fails, meaning the test suite will fail completely when run for the second time.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
