### PR TITLE
Fix missing filenames when encountering parse errors in Dhall files

### DIFF
--- a/app/Spago/Config.hs
+++ b/app/Spago/Config.hs
@@ -45,9 +45,9 @@ instance FromJSON Config
 type Expr = Dhall.DhallExpr Dhall.Import
 
 -- | Tries to read in a Spago Config
-parseConfig :: Spago m => Text -> m Config
-parseConfig dhallText = do
-  expr <- liftIO $ Dhall.inputExpr dhallText
+parseConfig :: Spago m => m Config
+parseConfig = do
+  expr <- liftIO $ Dhall.inputExpr $ "./" <> pathText
   case expr of
     Dhall.RecordLit ks -> do
       maybeConfig <- pure $ do
@@ -76,10 +76,10 @@ ensureConfig = do
   exists <- testfile path
   unless exists $ do
     die $ Messages.cannotFindConfig
-  PackageSet.ensureFrozen
-  configText <- readTextFile path
-  try (parseConfig configText) >>= \case
-    Right config -> pure config
+  try parseConfig >>= \case
+    Right config -> do
+      PackageSet.ensureFrozen
+      pure config
     Left (err :: Dhall.ReadError Dhall.TypeCheck.X) -> throwM err
 
 

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -229,7 +229,6 @@ freeze = do
   echo Messages.freezePackageSet
   liftIO $ do
     Dhall.Freeze.freeze (Just $ Text.unpack pathText) False Dhall.Pretty.ASCII defaultStandardVersion
-    Dhall.format pathText
 
 
 -- | Freeze the file if any of the remote imports are not frozen

--- a/app/Spago/PackageSet.hs
+++ b/app/Spago/PackageSet.hs
@@ -19,6 +19,7 @@ import qualified Data.Versions   as Version
 import qualified Dhall
 import           Dhall.Binary    (defaultStandardVersion)
 import qualified Dhall.Freeze
+import qualified Dhall.Pretty
 import qualified GitHub
 import           Network.URI     (parseURI)
 
@@ -227,7 +228,7 @@ freeze :: Spago m => m ()
 freeze = do
   echo Messages.freezePackageSet
   liftIO $ do
-    Dhall.Freeze.freeze (Just $ Text.unpack pathText) False defaultStandardVersion
+    Dhall.Freeze.freeze (Just $ Text.unpack pathText) False Dhall.Pretty.ASCII defaultStandardVersion
     Dhall.format pathText
 
 

--- a/app/Spago/Prelude.hs
+++ b/app/Spago/Prelude.hs
@@ -4,7 +4,7 @@ module Spago.Prelude
   , echoDebug
   , tshow
   , die
-  , throws
+  , Dhall.Core.throws
   , hush
   , pathFromText
   , assertDirectory
@@ -65,6 +65,7 @@ module Spago.Prelude
 
 import qualified Control.Concurrent.Async.Pool as Async
 import qualified Data.Text                     as Text
+import qualified Dhall.Core
 import qualified System.FilePath               as FilePath
 import qualified System.IO
 import qualified Turtle                        as Turtle
@@ -142,10 +143,6 @@ echoDebug str = do
 die :: MonadThrow m => Text -> m a
 die reason = throwM $ SpagoError reason
 
--- | Throw Lefts
-throws :: MonadThrow m => Exception e => Either e a -> m a
-throws (Left  e) = throwM e
-throws (Right a) = pure a
 
 -- | Suppress the 'Left' value of an 'Either'
 hush :: Either a b -> Maybe b

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,14 +2,14 @@ resolver: lts-12.21
 packages:
 - .
 extra-deps:
-- dhall-1.21.0
-- dhall-json-1.2.7
+- dhall-1.23.0
+- dhall-json-1.2.8
 - async-pool-0.9.0.2
 - cborg-json-0.2.1.0@sha256:af9137557002ca5308fe80570a9a29398dfb9708423870875223796760689ac3
 - versions-3.5.0
 - dotgen-0.4.2
 - megaparsec-7.0.3
-- repline-0.2.0.0
+- repline-0.2.1.0
 - serialise-0.2.1.0
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85
 - Glob-0.10.0


### PR DESCRIPTION
Fix #222 

New output:
```
spago:
↳ ./spago.dhall
  ↳ ./packages.dhall

Error: Invalid input

/Users/fabrizio/code/spago-test/packages.dhall:2:9:
  |
2 | Welcome to your new Dhall package-set!
  |         ^
unexpected 't'
expecting ':', '=', or whitespace


10:     ./packages.dhall

/Users/fabrizio/code/spago-test/spago.dhall:10:5
```

The problem here was that we were doing `ensureFrozen` before parsing the config properly, so the program would just blow up with poor error messages in case of parse errors. This moves the freezing to after the parsing, making it slower when encountering remote imports without hashes, but it's a one-off cost so it's fine.

This also bumps Dhall from `1.21` to `1.23`
