### PR TITLE
Export ps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bugfixes:
 - Fix `spago repl` starting on Windows where PureScript was installed with NPM (#235, #227)
 - Fix missing filenames when encountering parse errors in Dhall files (#241, #222)
 - Download packages in local repo instead of global tempdir (#243, #220)
+- Adds `--export` switch for `bundle-module` to allow use of PureScript modules from JS (#246)
 
 Other improvements:
 - Tests: test suite now works fully on Windows (#224)

--- a/README.md
+++ b/README.md
@@ -643,6 +643,28 @@ $ node -e "console.log(require('./index).main)"
 [Function]
 ```
 
+If you want to be able access modules and their functions from JavaScript land,
+(highly useful for use in `<script>` tags in the browser), then use can add
+the `--export` option for `bundle-module`, e.g.:
+
+```
+spago bundle-module --export --main Foo --to index.js
+```
+
+From your JS file that is used as input to e.g. parcel or another bundling tool,
+you can now reference your exported module:
+
+```
+// index.js
+
+import PS from "./index.opt.js";
+window.Foo = PS;
+```
+
+
+And within JavaScript (e.g. a `<script>` tag) you can now call functions like: `Foo.bar()`.
+
+
 #### Skipping the Build Step
 
 When running `spago bundle-app` and `spago bundle-module` the `build` step will also execute

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -61,11 +61,11 @@ data Command
 
   -- | Bundle the project into an executable
   --   Builds the project before bundling
-  | BundleApp (Maybe ModuleName) (Maybe TargetPath) NoBuild BuildOptions
+  | BundleApp (Maybe ModuleName) (Maybe TargetPath) Bool NoBuild BuildOptions
 
   -- | Bundle a module into a CommonJS module
   --   Builds the project before bundling
-  | BundleModule (Maybe ModuleName) (Maybe TargetPath) NoBuild BuildOptions
+  | BundleModule (Maybe ModuleName) (Maybe TargetPath) Bool NoBuild BuildOptions
 
   -- | Upgrade the package-set to the latest release
   | PackageSetUpgrade
@@ -134,6 +134,7 @@ parser = do
     toTarget    = CLI.optional (CLI.opt (Just . TargetPath) "to" 't' "The target file path")
     limitJobs   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     sourcePaths = CLI.many (CLI.opt (Just . SourcePath) "path" 'p' "Source path to include")
+    exportPS    = CLI.switch "export-ps" 'e' "Expose exported PureScript modules to JavaScript "
     packageName = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames = CLI.many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     passthroughArgs = many $ CLI.arg (Just . ExtraArg) " ..any `purs compile` option" "Options passed through to `purs compile`; use -- to separate"
@@ -190,13 +191,13 @@ parser = do
     bundleApp =
       ( "bundle-app"
       , "Bundle the project into an executable"
-      , BundleApp <$> mainModule <*> toTarget <*> noBuild <*> buildOptions
+      , BundleApp <$> mainModule <*> toTarget <*> exportPS <*> noBuild <*> buildOptions
       )
 
     bundleModule =
       ( "bundle-module"
       , "Bundle the project into a CommonJS module"
-      , BundleModule <$> mainModule <*> toTarget <*> noBuild <*> buildOptions
+      , BundleModule <$> mainModule <*> toTarget <*> exportPS <*> noBuild <*> buildOptions
       )
 
     docs =
@@ -332,10 +333,10 @@ main = do
       Test modName buildOptions             -> Spago.Build.test modName buildOptions
       Run modName buildOptions              -> Spago.Build.run modName buildOptions
       Repl paths pursArgs                   -> Spago.Build.repl paths pursArgs
-      BundleApp modName tPath shouldBuild buildOptions
-        -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions
-      BundleModule modName tPath shouldBuild buildOptions
-        -> Spago.Build.bundleModule modName tPath shouldBuild buildOptions
+      BundleApp modName tPath exportPS shouldBuild buildOptions
+        -> Spago.Build.bundleApp WithMain modName tPath exportPS shouldBuild buildOptions
+      BundleModule modName tPath exportPS shouldBuild buildOptions
+        -> Spago.Build.bundleModule modName tPath exportPS shouldBuild buildOptions
       Docs sourcePaths                      -> Spago.Build.docs sourcePaths
       Version                               -> printVersion
       PscPackageLocalSetup force            -> liftIO $ PscPackage.localSetup force

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -61,7 +61,7 @@ data Command
 
   -- | Bundle the project into an executable
   --   Builds the project before bundling
-  | BundleApp (Maybe ModuleName) (Maybe TargetPath) Bool NoBuild BuildOptions
+  | BundleApp (Maybe ModuleName) (Maybe TargetPath) NoBuild BuildOptions
 
   -- | Bundle a module into a CommonJS module
   --   Builds the project before bundling
@@ -134,7 +134,7 @@ parser = do
     toTarget    = CLI.optional (CLI.opt (Just . TargetPath) "to" 't' "The target file path")
     limitJobs   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     sourcePaths = CLI.many (CLI.opt (Just . SourcePath) "path" 'p' "Source path to include")
-    exportPS    = CLI.switch "export-ps" 'e' "Expose exported PureScript modules to JavaScript "
+    exportPS    = CLI.switch "export" 'e' "Expose exported PureScript modules to JavaScript "
     packageName = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames = CLI.many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     passthroughArgs = many $ CLI.arg (Just . ExtraArg) " ..any `purs compile` option" "Options passed through to `purs compile`; use -- to separate"
@@ -191,7 +191,7 @@ parser = do
     bundleApp =
       ( "bundle-app"
       , "Bundle the project into an executable"
-      , BundleApp <$> mainModule <*> toTarget <*> exportPS <*> noBuild <*> buildOptions
+      , BundleApp <$> mainModule <*> toTarget <*> noBuild <*> buildOptions
       )
 
     bundleModule =
@@ -333,8 +333,8 @@ main = do
       Test modName buildOptions             -> Spago.Build.test modName buildOptions
       Run modName buildOptions              -> Spago.Build.run modName buildOptions
       Repl paths pursArgs                   -> Spago.Build.repl paths pursArgs
-      BundleApp modName tPath exportPS shouldBuild buildOptions
-        -> Spago.Build.bundleApp WithMain modName tPath exportPS shouldBuild buildOptions
+      BundleApp modName tPath shouldBuild buildOptions
+        -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions
       BundleModule modName tPath exportPS shouldBuild buildOptions
         -> Spago.Build.bundleModule modName tPath exportPS shouldBuild buildOptions
       Docs sourcePaths                      -> Spago.Build.docs sourcePaths

--- a/app/Spago/Build.hs
+++ b/app/Spago/Build.hs
@@ -123,10 +123,11 @@ bundleApp
   => Purs.WithMain
   -> Maybe Purs.ModuleName
   -> Maybe Purs.TargetPath
+  -> Bool
   -> NoBuild
   -> BuildOptions
   -> m ()
-bundleApp withMain maybeModuleName maybeTargetPath noBuild buildOpts =
+bundleApp withMain maybeModuleName maybeTargetPath exportPS noBuild buildOpts =
   let (moduleName, targetPath) = prepareBundleDefaults maybeModuleName maybeTargetPath
       bundleAction = Purs.bundle withMain moduleName targetPath
   in case noBuild of
@@ -138,10 +139,11 @@ bundleModule
   :: Spago m
   => Maybe Purs.ModuleName
   -> Maybe Purs.TargetPath
+  -> Bool
   -> NoBuild
   -> BuildOptions
   -> m ()
-bundleModule maybeModuleName maybeTargetPath noBuild buildOpts = do
+bundleModule maybeModuleName maybeTargetPath exportPS noBuild buildOpts = do
   let (moduleName, targetPath) = prepareBundleDefaults maybeModuleName maybeTargetPath
       jsExport = Text.unpack $ "\nmodule.exports = PS[\""<> Purs.unModuleName moduleName <> "\"];"
       bundleAction = do

--- a/app/Spago/Build.hs
+++ b/app/Spago/Build.hs
@@ -123,11 +123,10 @@ bundleApp
   => Purs.WithMain
   -> Maybe Purs.ModuleName
   -> Maybe Purs.TargetPath
-  -> Bool
   -> NoBuild
   -> BuildOptions
   -> m ()
-bundleApp withMain maybeModuleName maybeTargetPath exportPS noBuild buildOpts =
+bundleApp withMain maybeModuleName maybeTargetPath noBuild buildOpts =
   let (moduleName, targetPath) = prepareBundleDefaults maybeModuleName maybeTargetPath
       bundleAction = Purs.bundle withMain moduleName targetPath
   in case noBuild of
@@ -145,7 +144,10 @@ bundleModule
   -> m ()
 bundleModule maybeModuleName maybeTargetPath exportPS noBuild buildOpts = do
   let (moduleName, targetPath) = prepareBundleDefaults maybeModuleName maybeTargetPath
-      jsExport = Text.unpack $ "\nmodule.exports = PS[\""<> Purs.unModuleName moduleName <> "\"];"
+      jsExport = Text.unpack $ "\nmodule.exports = PS[\"" <>
+        Purs.unModuleName moduleName <> "\"];" <> case exportPS of
+          True -> "\nexport default PS;\n"
+          False -> ""
       bundleAction = do
         echo "Bundling first..."
         Purs.bundle Purs.WithoutMain moduleName targetPath

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,5 @@ extra-deps:
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85
 - Glob-0.10.0
 - turtle-1.5.14
+nix:
+  packages: [zlib]


### PR DESCRIPTION
### Adding an --export option so that exported modules can be used from JavaScript easily.

This is a switch for `bundle-module`; if `-e` or `--export` are given then `export default PS;` is tacked to the end of the file.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable) 
   - I tested this manually, but haven't looked to see if it is applicable - let me know.

**Note**: Suggest a squash and merge
