### PR TITLE
Enable easier usage of stack within nix

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,5 @@ extra-deps:
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85
 - Glob-0.10.0
 - turtle-1.5.14
+nix:
+  packages: [zlib]


### PR DESCRIPTION
### Description of the change

I tested this in my nix setup using `stack --nix build` - I think this is fairly standard.


### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
 - I don't think it is really necessary? It should only affect new users building spago in a particular way.
- [ ] Added some example of the new feature to the `README`
 - I don't think it is really necessary.
- [ ] Added a test for the contribution (if applicable)
 - N/A

