### PR TITLE
Read purs version from inside the set instead of its GitHub tag

### DIFF
--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -28,11 +28,10 @@ import qualified Turtle
 
 import           Data.Aeson.Encode.Pretty       (encodePretty)
 import           Spago.GlobalCache
-import           Spago.PackageSet               (Package (..), PackageName (..), PackageSet,
-                                                 Repo (..))
+import           Spago.PackageSet               (Package (..), PackageName (..), Repo (..))
 
 type Expr = Dhall.DhallExpr Dhall.Import
-
+type PackageSetMap = Map PackageName Package
 
 
 data SpagoUpdaterMessage
@@ -47,7 +46,7 @@ data MetadataUpdaterMessage
 
 data PackageSetsUpdaterMessage
   = MLatestTag !PackageName !Text !Tag
-  | MPackageSet !PackageSet
+  | MPackageSet !PackageSetMap
 
 
 -- | Main loop. Setup folders, repos, channels and threads, and then control them
@@ -240,7 +239,7 @@ fetcher token controlChan metadataChan psChan = forever $ do
         atomically $ Queue.writeTQueue metadataChan $ MMetadata packageName RepoMetadataV1{..}
 
     -- | Tries to read in a PackageSet from GitHub
-    fetchPackageSet :: Text -> IO PackageSet
+    fetchPackageSet :: Text -> IO PackageSetMap
     fetchPackageSet tag = do
       let packageTyp = Dhall.genericAuto :: Dhall.Type Package
       expr <- Dhall.inputExpr ("https://raw.githubusercontent.com/purescript/package-sets/" <> tag <> "/src/packages.dhall")

--- a/package.yaml
+++ b/package.yaml
@@ -37,70 +37,97 @@ default-extensions:
 - NoImplicitPrelude
 - ApplicativeDo
 
-dependencies:
-- base >= 4.7 && < 5
-- text < 1.3
-- turtle
-- filepath
-- file-embed
-- template-haskell
-- aeson
-- aeson-pretty
-- containers
-- dhall
-- dhall-json
-- bytestring
-- prettyprinter
-- async-pool
-- process
-- network-uri
-- github
-- versions
-- lens
-- safe
-- fsnotify
-- Glob
-- async
-- stm
-- directory
-- mtl
-- exceptions
-- unliftio
-- vector
-- temporary
-- zlib
-- tar
-- foldl
-- retry
-- optparse-applicative
-- http-conduit
-- time
-
 
 library:
   source-dirs: src
+  dependencies:
+  - base >= 4.7 && < 5
+  - text < 1.3
+  - turtle
+  - filepath
+  - file-embed
+  - template-haskell
+  - aeson
+  - aeson-pretty
+  - containers
+  - dhall
+  - dhall-json
+  - bytestring
+  - prettyprinter
+  - async-pool
+  - process
+  - network-uri
+  - github
+  - versions
+  - lens
+  - safe
+  - fsnotify
+  - Glob
+  - stm
+  - directory
+  - mtl
+  - exceptions
+  - unliftio
+  - vector
+  - temporary
+  - zlib
+  - tar
+  - foldl
+  - http-conduit
+  - time
+
 executables:
   spago:
     main:                Spago.hs
     source-dirs:         app
-    dependencies:        [spago]
+    other-modules:       [ Paths_spago ]
     ghc-options:
     - -main-is Spago
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - spago
+    - base >= 4.7 && < 5
+    - text < 1.3
+    - turtle
+    - optparse-applicative
+
   spago-curator:
     main:                Curator.hs
     source-dirs:         app
-    dependencies:        [spago]
+    other-modules:       []
     ghc-options:
     - -main-is Curator
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - spago
+    - base >= 4.7 && < 5
+    - text < 1.3
+    - turtle
+    - filepath
+    - aeson-pretty
+    - containers
+    - dhall
+    - bytestring
+    - async-pool
+    - process
+    - github
+    - lens
+    - stm
+    - vector
+    - temporary
+    - retry
 
 tests:
   spec:
     defaults: hspec/hspec@master
     dependencies:
+    - base >= 4.7 && < 5
+    - text < 1.3
+    - turtle
+    - process
+    - directory
     - extra

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -26,6 +26,7 @@ import qualified Spago.Config         as Config
 import qualified Spago.FetchPackage   as Fetch
 import qualified Spago.GlobalCache    as GlobalCache
 import qualified Spago.Packages       as Packages
+import qualified Spago.PackageSet     as PackageSet
 import qualified Spago.Purs           as Purs
 import qualified Spago.Watch          as Watch
 
@@ -65,9 +66,9 @@ prepareBundleDefaults maybeModuleName maybeTargetPath = (moduleName, targetPath)
 build :: Spago m => BuildOptions -> Maybe (m ()) -> m ()
 build BuildOptions{..} maybePostBuild = do
   echoDebug "Running `spago build`"
-  config <- Config.ensureConfig
+  config@Config.Config{ packageSet = PackageSet.PackageSet{..}, ..} <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
-  Fetch.fetchPackages maybeLimit cacheConfig deps
+  Fetch.fetchPackages maybeLimit cacheConfig deps packagesMinPursVersion
   let projectGlobs = defaultSourcePaths <> sourcePaths
       allGlobs = Packages.getGlobs deps <> projectGlobs
       buildAction = do

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -60,8 +60,8 @@ parseConfig = do
           something -> Left $ Dhall.PackagesIsNotRecord something
 
         let metadataPackageName = PackageSet.PackageName "metadata"
-            (metadataMap, setPackages) = Map.partitionWithKey (\k _v -> k == metadataPackageName) packages
-            setMinPursVersion = join
+            (metadataMap, packagesDB) = Map.partitionWithKey (\k _v -> k == metadataPackageName) packages
+            packagesMinPursVersion = join
               $ fmap (hush . Version.semver . (Text.replace "v" "") . PackageSet.version)
               $ Map.lookup metadataPackageName metadataMap
             packageSet = PackageSet.PackageSet{..}

--- a/src/Spago/FetchPackage.hs
+++ b/src/Spago/FetchPackage.hs
@@ -8,11 +8,12 @@ import           Spago.Prelude
 import qualified Control.Concurrent.Async.Pool as Async
 import qualified Data.List                     as List
 import qualified Data.Text                     as Text
-import qualified UnliftIO.Directory              as Directory
+import qualified Data.Versions                 as Version
 import qualified System.FilePath               as FilePath
 import qualified System.IO.Temp                as Temp
 import qualified System.Process                as Process
 import qualified Turtle
+import qualified UnliftIO.Directory            as Directory
 
 import qualified Spago.GlobalCache             as GlobalCache
 import qualified Spago.Messages                as Messages
@@ -28,11 +29,17 @@ import qualified Spago.PackageSet              as PackageSet
 --     * then check if the Package is on GitHub and an "immutable" ref:
 --       * if yes, download the tar archive and copy it to global and then local cache
 --       * if not, run a series of git commands to get the code, and copy to local cache
-fetchPackages :: Spago m => Maybe Int -> Maybe GlobalCache.CacheFlag -> [(PackageName, Package)] -> m ()
-fetchPackages maybeLimit globalCacheFlag allDeps = do
+fetchPackages
+  :: Spago m
+  => Maybe Int
+  -> Maybe GlobalCache.CacheFlag
+  -> [(PackageName, Package)]
+  -> Maybe Version.SemVer
+  -> m ()
+fetchPackages maybeLimit globalCacheFlag allDeps minPursVersion = do
   echoDebug "Running `fetchPackages`"
 
-  PackageSet.checkPursIsUpToDate
+  PackageSet.checkPursIsUpToDate minPursVersion
 
   -- Ensure both local and global cache dirs are there
   GlobalCache.getGlobalCacheDir >>= assertDirectory

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -122,12 +122,13 @@ pursVersionMismatch :: Text -> Text -> Text
 pursVersionMismatch currentVersion minVersion = makeMessage
   [ "Oh noes! It looks like the PureScript version installed on your system is not compatible with the package-set you're using."
   , ""
-  , "installed version:   " <> currentVersion
-  , "package-set version: " <> minVersion
+  , "installed `purs` version:    " <> currentVersion
+  , "minimum package-set version: " <> minVersion
   , ""
   , "There are a few ways to solve this:"
-  , "- install a compatible `purs` version (i.e. in the same 'semver range')"
-  , "- if you know what you're doing, you can override the `version` of the `metadata` package in the packages.dhall"
+  , "- install a compatible `purs` version (i.e. in the same 'semver range' as the one in the package set)"
+  , "- if the `purs` version is 'too new', you can try using `spago package-set-upgrade` to upgrade to the latest package set"
+  , "- if you know what you're doing and you want to void this check, you can override the `version` of the `metadata` package in the packages.dhall"
   , ""
   ]
 

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -120,13 +120,14 @@ packageSetVersionWarning = makeMessage
 
 pursVersionMismatch :: Text -> Text -> Text
 pursVersionMismatch currentVersion minVersion = makeMessage
-  [ "Oh noes! It looks like the PureScript version installed on your system is"
-  , "outdated for the package-set you're using."
+  [ "Oh noes! It looks like the PureScript version installed on your system is not compatible with the package-set you're using."
   , ""
   , "installed version:   " <> currentVersion
   , "package-set version: " <> minVersion
   , ""
-  , "Please upgrade your `purs` version."
+  , "There are a few ways to solve this:"
+  , "- install a compatible `purs` version (i.e. in the same 'semver range')"
+  , "- if you know what you're doing, you can override the `version` of the `metadata` package in the packages.dhall"
   , ""
   ]
 

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -6,7 +6,7 @@ module Spago.PackageSet
   , ensureFrozen
   , path
   , pathText
-  , PackageSet
+  , PackageSet(..)
   , Package (..)
   , PackageName (..)
   , Repo (..)
@@ -45,7 +45,11 @@ data Package = Package
 instance ToJSON Package
 instance FromJSON Package
 
-type PackageSet = Map PackageName Package
+data PackageSet = PackageSet
+  { packagesDB        :: Map PackageName Package
+  , setMinPursVersion :: Maybe Version.SemVer
+  }
+  deriving (Show, Generic)
 
 -- | We consider a "Repo" a "box of source to include in the build"
 --   This can have different nature:

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -24,7 +24,7 @@ import qualified Spago.Config       as Config
 import qualified Spago.FetchPackage as Fetch
 import           Spago.GlobalCache  (CacheFlag (..))
 import qualified Spago.Messages     as Messages
-import           Spago.PackageSet   (Package (..), PackageName (..), PackageSet)
+import           Spago.PackageSet   (Package (..), PackageName (..), PackageSet (..))
 import qualified Spago.PackageSet   as PackageSet
 import qualified Spago.Purs         as Purs
 import qualified Spago.Templates    as Templates
@@ -82,14 +82,14 @@ getGlobs = map (\pair
 
 -- | Return all the transitive dependencies of the current project
 getProjectDeps :: Spago m => Config -> m [(PackageName, Package)]
-getProjectDeps Config{..} = getTransitiveDeps packages dependencies
+getProjectDeps Config{..} = getTransitiveDeps packageSet dependencies
 
 
 -- | Return the transitive dependencies of a list of packages
 --   Code basically from here:
 --   https://github.com/purescript/psc-package/blob/648da70ae9b7ed48216ed03f930c1a6e8e902c0e/app/Main.hs#L227
 getTransitiveDeps :: Spago m => PackageSet -> [PackageName] -> m [(PackageName, Package)]
-getTransitiveDeps packageSet deps = do
+getTransitiveDeps PackageSet{..} deps = do
   echoDebug "Getting transitive deps"
   Map.toList . fold <$> traverse (go Set.empty) deps
   where
@@ -97,7 +97,7 @@ getTransitiveDeps packageSet deps = do
       | dep `Set.member` seen =
           die $ "Cycle in package dependencies at package " <> packageName dep
       | otherwise =
-        case Map.lookup dep packageSet of
+        case Map.lookup dep packagesDB of
           Nothing ->
             die $ pkgNotFoundMsg dep
           Just info@Package{..} -> do
@@ -108,7 +108,7 @@ getTransitiveDeps packageSet deps = do
       "Package `" <> packageName pkg <> "` does not exist in package set" <> extraHelp
       where
         extraHelp = case suggestedPkg of
-          Just pkg' | Map.member pkg' packageSet ->
+          Just pkg' | Map.member pkg' packagesDB ->
             ", but `" <> packageName pkg' <> "` does, did you mean that instead?"
           Just pkg' ->
             ", and nor does `" <> packageName pkg' <> "`"
@@ -121,14 +121,14 @@ getTransitiveDeps packageSet deps = do
 
 
 getReverseDeps  :: PackageSet -> PackageName -> IO [(PackageName, Package)]
-getReverseDeps db dep = do
-    List.nub <$> foldMap go (Map.toList db)
+getReverseDeps packageSet@PackageSet{..} dep = do
+    List.nub <$> foldMap go (Map.toList packagesDB)
   where
     go pair@(packageName, Package {..}) =
       case List.find (== dep) dependencies of
         Nothing -> return mempty
         Just _ -> do
-          innerDeps <- getReverseDeps db packageName
+          innerDeps <- getReverseDeps packageSet packageName
           return $ pair : innerDeps
 
 
@@ -159,12 +159,12 @@ data PackagesFilter = TransitiveDeps | DirectDeps
 listPackages :: Spago m => Maybe PackagesFilter -> m ()
 listPackages packagesFilter = do
   echoDebug "Running `listPackages`"
-  Config{..} <- Config.ensureConfig
+  Config{packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfig
   packagesToList :: [(PackageName, Package)] <- case packagesFilter of
-    Nothing             -> pure $ Map.toList packages
-    Just TransitiveDeps -> getTransitiveDeps packages dependencies
+    Nothing             -> pure $ Map.toList $ packagesDB
+    Just TransitiveDeps -> getTransitiveDeps packageSet dependencies
     Just DirectDeps     -> pure $ Map.toList
-      $ Map.restrictKeys packages (Set.fromList dependencies)
+      $ Map.restrictKeys packagesDB (Set.fromList dependencies)
 
   case packagesToList of
     [] -> echo "There are no dependencies listed in your spago.dhall"
@@ -203,22 +203,22 @@ sources = do
 verify :: Spago m => Maybe Int -> Maybe CacheFlag -> Maybe PackageName -> m ()
 verify maybeLimit cacheFlag maybePackage = do
   echoDebug "Running `spago verify`"
-  Config{..} <- Config.ensureConfig
+  Config{ packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfig
   case maybePackage of
     -- If no package is specified, verify all of them
-    Nothing -> verifyPackages packages (Map.toList packages)
+    Nothing -> verifyPackages packageSet (Map.toList packagesDB)
     -- In case we have a package, search in the package set for it
     Just packageName -> do
-      case Map.lookup packageName packages of
+      case Map.lookup packageName packagesDB of
         Nothing -> die $ "No packages found with the name " <> Text.pack (show packageName)
         -- When verifying a single package we check the reverse deps/referrers
         -- because we want to make sure the it doesn't break them
         -- (without having to check the whole set of course, that would work
         -- as well but would be much slower)
         Just package -> do
-          reverseDeps <- liftIO $ getReverseDeps packages packageName
+          reverseDeps <- liftIO $ getReverseDeps packageSet packageName
           let toVerify = [(packageName, package)] <> reverseDeps
-          verifyPackages packages toVerify
+          verifyPackages packageSet toVerify
   where
     verifyPackages :: Spago m => PackageSet -> [(PackageName, Package)] -> m ()
     verifyPackages packageSet packages = do

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -136,7 +136,7 @@ getReverseDeps packageSet@PackageSet{..} dep = do
 install :: Spago m => Maybe Int -> Maybe CacheFlag -> [PackageName] -> m ()
 install maybeLimit cacheFlag newPackages = do
   echoDebug "Running `spago install`"
-  config@Config{..} <- Config.ensureConfig
+  config@Config{ packageSet = PackageSet{..}, ..} <- Config.ensureConfig
 
   -- Try fetching the dependencies with the new names too
   let newConfig :: Config
@@ -149,7 +149,7 @@ install maybeLimit cacheFlag newPackages = do
     []         -> pure ()
     additional -> Config.addDependencies config additional
 
-  Fetch.fetchPackages maybeLimit cacheFlag deps
+  Fetch.fetchPackages maybeLimit cacheFlag deps packagesMinPursVersion
 
 
 data PackagesFilter = TransitiveDeps | DirectDeps
@@ -226,11 +226,11 @@ verify maybeLimit cacheFlag maybePackage = do
       traverse_ (verifyPackage packageSet) (fst <$> packages)
 
     verifyPackage :: Spago m => PackageSet -> PackageName -> m ()
-    verifyPackage packageSet name = do
+    verifyPackage packageSet@PackageSet{..} name = do
       deps <- getTransitiveDeps packageSet [name]
       let globs = getGlobs deps
           quotedName = Messages.surroundQuote $ packageName name
-      Fetch.fetchPackages maybeLimit cacheFlag deps
+      Fetch.fetchPackages maybeLimit cacheFlag deps packagesMinPursVersion
       echo $ "Verifying package " <> quotedName
       Purs.compile globs []
       echo $ "Successfully verified " <> quotedName


### PR DESCRIPTION
Currently `spago` tries to find out which `purs` version is supported by the set by reading the GitHub tag the upstream comes from. This brings a whole bunch of issues, e.g. we cannot ensure anything if the package set comes from somewhere else, this check is hard to override, etc.

Once https://github.com/purescript/package-sets/pull/343 lands we'll be able to read the "minimum supported purs version" just as the version of one of the packages in the set.

This fixes #225, because we:
- fix the error message to just say "SemVer mismatch" instead of newer/older
- make the "minimum purs version" easily overridable, as it's just the version of a package, so there's no need for a flag
- make this version check actually robust, as we're not trying to climb the Dhall import chain from the AST anymore

An unrelated change coming in this PR too is that I run the package through [weeder](http://hackage.haskell.org/package/weeder) and trimmed the dependencies we use