### PR TITLE
Skip copy to global cache if we encounter the openBinaryFile problem due to permissions

### DIFF
--- a/src/Spago/FetchPackage.hs
+++ b/src/Spago/FetchPackage.hs
@@ -120,7 +120,8 @@ fetchPackage metadata pair@(packageName'@PackageName{..}, Package{ repo = Remote
               let resultDir2 = path </> "download2"
               assertDirectory resultDir2
               cptree resultDir resultDir2
-              mv resultDir packageGlobalCacheDir
+              catch (mv resultDir packageGlobalCacheDir) $ \(err :: SomeException) -> do
+                echoStr $ "WARNING: was not able to copy the download to the global cache. Error: " <> show err
               mv resultDir2 packageLocalCacheDir
 
         -- * if not, run a series of git commands to get the code, and move it to local cache

--- a/src/Spago/FetchPackage.hs
+++ b/src/Spago/FetchPackage.hs
@@ -120,8 +120,8 @@ fetchPackage metadata pair@(packageName'@PackageName{..}, Package{ repo = Remote
               let resultDir2 = path </> "download2"
               assertDirectory resultDir2
               cptree resultDir resultDir2
-              catch (mv resultDir packageGlobalCacheDir) $ \(err :: SomeException) -> do
-                echoStr $ "WARNING: was not able to copy the download to the global cache. Error: " <> show err
+              catch (mv resultDir packageGlobalCacheDir) $ \(err :: SomeException) ->
+                echo $ Messages.failedToCopyToGlobalCache err
               mv resultDir2 packageLocalCacheDir
 
         -- * if not, run a series of git commands to get the code, and move it to local cache

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -131,7 +131,7 @@ getMetadata cacheFlag = do
           ) >>= \case
         Right v -> pure v
         Left (err :: IOException) -> do
-          echoStr $ "Warning: unable to read metadata file: " <> show err
+          echoDebug $ "Unable to read metadata file. Error was: " <> tshow err
           pure True
 
       case shouldDownloadMeta of

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -109,6 +109,14 @@ freezePackageSet = makeMessage
   [ "Generating new hashes for the package set file so it will be cached.. (this might take some time)"
   ]
 
+failedToCopyToGlobalCache :: Show a => a -> Text
+failedToCopyToGlobalCache err = makeMessage
+  [ "WARNING: was not able to copy the download to the global cache."
+  , "Most likely this comes from permissions not being right, so you could try setting the `XDG_CACHE_HOME` env variable (which determines where the global cache is) to a location which is writable by your user."
+  , "Error was:"
+  , tshow err
+  ]
+
 packageSetVersionWarning :: Text
 packageSetVersionWarning = makeMessage
  [ "WARNING: the package-set version you're on doesn't check if the version of the"


### PR DESCRIPTION
It is still possible to encounter the `openBinaryFile: inappropriate type (is a directory)` issue in case of wrong permissions with the global cache.

It's possile to work around this by:
- setting the `XDG_CACHE_HOME` env variable to some place where the current user can write
- disabling the global cache entirely with `global-cache skip`

However, we can also just 
1. skip the copy to the global cache
2. fail with a nice error
3. suggest the first solution if the user wants to keep a global cache (since the second one is basically default behaviour now) 