### PR TITLE
add json output option for listing packages

### DIFF
--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -16,7 +16,7 @@ import           Spago.Build         (BuildOptions (..), ExtraArg (..), ModuleNa
 import qualified Spago.Build
 import           Spago.GlobalCache   (CacheFlag (..))
 import           Spago.Messages      as Messages
-import           Spago.Packages      (PackageName (..), PackagesFilter (..))
+import           Spago.Packages      (PackageName (..), PackagesFilter (..), JsonFlag(..))
 import qualified Spago.Packages
 import qualified Spago.PscPackage    as PscPackage
 
@@ -45,7 +45,7 @@ data Command
   | Build BuildOptions
 
   -- | List available packages
-  | ListPackages (Maybe PackagesFilter)
+  | ListPackages (Maybe PackagesFilter) JsonFlag
 
   -- | Verify that a single package is consistent with the Package Set
   | Verify (Maybe Int) (Maybe CacheFlag) PackageName
@@ -124,6 +124,12 @@ parser = do
       pure $ case res of
         True  -> NoBuild
         False -> DoBuild
+    jsonFlagBool = CLI.switch "json" 'j' "Produce JSON output"
+    jsonFlag = do
+      res <- jsonFlagBool
+      pure $ case res of
+        True  -> JsonOutputYes
+        False -> JsonOutputNo
     cacheFlag =
       let wrap = \case
             "skip" -> Just SkipCache
@@ -231,7 +237,7 @@ parser = do
     listPackages =
       ( "list-packages"
       , "List packages available in your packages.dhall"
-      , ListPackages <$> packagesFilter
+      , ListPackages <$> packagesFilter <*> jsonFlag
       )
 
     verify =
@@ -322,7 +328,7 @@ main = do
       Init force                            -> Spago.Packages.initProject force
       Install limitJobs cacheConfig packageNames
         -> Spago.Packages.install limitJobs cacheConfig packageNames
-      ListPackages packagesFilter           -> Spago.Packages.listPackages packagesFilter
+      ListPackages packagesFilter jsonFlag  -> Spago.Packages.listPackages packagesFilter jsonFlag
       Sources                               -> Spago.Packages.sources
       Verify limitJobs cacheConfig package  -> Spago.Packages.verify limitJobs cacheConfig (Just package)
       VerifySet limitJobs cacheConfig       -> Spago.Packages.verify limitJobs cacheConfig Nothing

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ default-extensions:
 - ConstraintKinds
 - NoImplicitPrelude
 - ApplicativeDo
+- NamedFieldPuns
 
 
 library:


### PR DESCRIPTION
### Description of the change

i need this

```
馬 ~/Code/format-nix master 異物 $ spago list-packages -f transitive -j | head -5
{"packageName":"aff","version":"v5.1.1","repo":{"tag":"Remote","contents":"https://github.com/slamdata/purescript-aff.git"}}
{"packageName":"arraybuffer-types","version":"v2.0.0","repo":{"tag":"Remote","contents":"https://github.com/purescript-contrib/purescript-arraybuffer-types.git"}}
{"packageName":"arrays","version":"v5.3.0","repo":{"tag":"Remote","contents":"https://github.com/purescript/purescript-arrays.git"}}
{"packageName":"bifunctors","version":"v4.0.0","repo":{"tag":"Remote","contents":"https://github.com/purescript/purescript-bifunctors.git"}}
{"packageName":"console","version":"v4.2.0","repo":{"tag":"Remote","contents":"https://github.com/purescript/purescript-console.git"}}
```

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊