### PR TITLE
Report all missing packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Bugfixes:
+- Report all missing packages together (#223)
 
 ## [0.8.4] - 2019-06-11
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -80,7 +80,7 @@ spec = around_ setup $ do
 
       writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
       spago ["init"] >>= shouldBeSuccess
-      spago ["install", "foobar"] >>= shouldBeFailureOutput "missing-dependencies.txt"
+      spago ["install", "foo", "bar"] >>= shouldBeFailureOutput "missing-dependencies.txt"
       mv "spago.dhall" "spago-install-failure.dhall"
       checkFixture "spago-install-failure.dhall"
 

--- a/test/fixtures/circular-dependencies.txt
+++ b/test/fixtures/circular-dependencies.txt
@@ -1,1 +1,3 @@
-spago: Cycle in package dependencies at package a
+spago: The following packages have circular dependencies:
+  - a
+  - b

--- a/test/fixtures/missing-dependencies.txt
+++ b/test/fixtures/missing-dependencies.txt
@@ -1,1 +1,3 @@
-spago: Package `foobar` does not exist in package set
+spago: The following packages do not exist in your package set:
+  - bar
+  - foo


### PR DESCRIPTION
### Description of the change
If there are multiple dependencies which do not exist in the package set, instead of just reporting the first missing package, all missing packages will be reported which fixes #223. In the same manner, all circular dependency errors will be reported. 

### Checklist:
- [x] Added the change to the "Unreleased" section of the changelog
- [ ] ~~Added some example of the new feature to the `README`~~
- [ ] ~~Added a test for the contribution (if applicable)~~