### PR TITLE
Untangle testcases environments

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -131,4 +131,5 @@ tests:
     - turtle
     - process
     - directory
+    - temporary
     - extra

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -1,26 +1,23 @@
 module SpagoSpec (spec) where
 
-import           Control.Concurrent  (threadDelay)
-import           Control.Monad.Extra (whenM)
-import           Prelude             hiding (FilePath)
-import           Test.Hspec          (Spec, around_, beforeAll, describe, it,
-                                      shouldBe)
-import           Turtle              (FilePath, cp, mkdir, mv, readTextFile, rm,
-                                      testdir, writeTextFile)
-import           Utils               (checkFixture, rmtree, runFor, shouldBeFailure,
-                                      shouldBeFailureOutput, shouldBeSuccess,
-                                      shouldBeSuccessOutput, spago, withCwd)
+import           Control.Concurrent (threadDelay)
+import           Prelude            hiding (FilePath)
+import qualified System.IO.Temp     as Temp
+import           Test.Hspec         (Spec, around_, describe, it, shouldBe)
+import           Turtle             (cp, decodeString, mkdir, mktree, mv, readTextFile, testdir,
+                                     writeTextFile)
+import           Utils              (checkFixture, runFor, shouldBeFailure, shouldBeFailureOutput,
+                                     shouldBeSuccess, shouldBeSuccessOutput, spago, withCwd)
 
-testDir :: FilePath
-testDir = "test/spago-test"
 
-clean :: IO ()
-clean = do
-  whenM (testdir testDir) (rmtree testDir)
-  mkdir testDir
+setup :: IO () -> IO ()
+setup cmd = do
+  Temp.withTempDirectory "test/" "spago-test" $ \temp -> do
+    -- print ("Running in " <> temp)
+    withCwd (decodeString temp) cmd
 
 spec :: Spec
-spec = beforeAll clean $ around_ (withCwd testDir) $ do
+spec = around_ setup $ do
 
   describe "spago init" $ do
 
@@ -30,26 +27,25 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should refuse to overwrite an existing project without -f" $ do
 
+      spago ["init"] >>= shouldBeSuccess
       spago ["init"] >>= shouldBeFailure
-
-      rm "spago.dhall" :: IO ()
-      rm "packages.dhall"
 
     it "Spago should not overwrite files when initing a project" $ do
 
+      mktree "src"
       writeTextFile "src/Main.purs" "Something"
       spago ["init"] >>= shouldBeSuccess
       readTextFile "src/Main.purs" >>= (`shouldBe` "Something")
-      rmtree "src"
 
     it "Spago should always succeed in doing init with force" $ do
 
+      spago ["init"] >>= shouldBeSuccess
       spago ["init", "-f"] >>= shouldBeSuccess
 
     it "Spago should import config from psc-package" $ do
 
       writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
-      spago ["init", "-f"] >>= shouldBeSuccess
+      spago ["init"] >>= shouldBeSuccess
       cp "spago.dhall" "spago-psc-success.dhall"
       checkFixture "spago-psc-success.dhall"
 
@@ -65,6 +61,7 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Subsequent installs should succeed after failed install" $ do
 
+      spago ["init"] >>= shouldBeSuccess
       -- Run `install` once and kill it soon to simulate failure
       runFor 5000 "spago" ["install", "-j", "3"]
       -- Sleep for some time, as the above might take time to cleanup old processes
@@ -73,20 +70,22 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should be able to add dependencies" $ do
 
+      writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
+      spago ["init"] >>= shouldBeSuccess
       spago ["install", "-j10", "simple-json", "foreign"] >>= shouldBeSuccess
       mv "spago.dhall" "spago-install-success.dhall"
       checkFixture "spago-install-success.dhall"
 
     it "Spago should not add dependencies that are not in the package set" $ do
 
-      spago ["init", "-f"] >>= shouldBeSuccess
+      writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
+      spago ["init"] >>= shouldBeSuccess
       spago ["install", "foobar"] >>= shouldBeFailure
       mv "spago.dhall" "spago-install-failure.dhall"
       checkFixture "spago-install-failure.dhall"
 
     it "Spago should be able to install a package in the set from a commit hash" $ do
 
-      rm "psc-package.json"
       spago ["init"] >>= shouldBeSuccess
       mv "packages.dhall" "packagesBase.dhall"
       writeTextFile "packages.dhall" "let pkgs = ./packagesBase.dhall in pkgs // { simple-json = pkgs.simple-json // { version = \"d45590f493d68baae174b2d3062d502c0cc4c265\" } }"
@@ -94,40 +93,47 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should be able to install a package not in the set from a commit hash" $ do
 
+      spago ["init"] >>= shouldBeSuccess
+      mv "packages.dhall" "packagesBase.dhall"
       writeTextFile "packages.dhall" "let pkgs = ./packagesBase.dhall in pkgs // { spago = { dependencies = [\"prelude\"], repo = \"https://github.com/spacchetti/spago.git\", version = \"cbdbbf8f8771a7e43f04b18cdefffbcb0f03a990\" }}"
       spago ["install", "spago"] >>= shouldBeSuccess
 
     it "Spago should not be able to install a package from a not-existing commit hash" $ do
 
+      spago ["init"] >>= shouldBeSuccess
+      mv "packages.dhall" "packagesBase.dhall"
       writeTextFile "packages.dhall" "let pkgs = ./packagesBase.dhall in pkgs // { spago = { dependencies = [\"prelude\"], repo = \"https://github.com/spacchetti/spago.git\", version = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" }}"
       spago ["install", "spago"] >>= shouldBeFailure
-      rm "packages.dhall"
-      rm "packagesBase.dhall"
-      rm "spago.dhall"
-      spago ["init"] >>= shouldBeSuccess
 
   describe "spago build" $ do
 
     it "Spago should build successfully" $ do
 
+      spago ["init"] >>= shouldBeSuccess
       spago ["build"] >>= shouldBeSuccess
 
     it "Spago should pass options to purs" $ do
 
+      spago ["init"] >>= shouldBeSuccess
       spago ["build", "--", "-o", "myOutput"] >>= shouldBeSuccess
       testdir "myOutput" >>= (`shouldBe` True)
 
     it "Spago should build successfully with sources included from custom path" $ do
+
+      spago ["init"] >>= shouldBeSuccess
       mkdir "another_source_path"
       mv "src/Main.purs" "another_source_path/Main.purs"
       spago ["build", "--path", "another_source_path/*.purs"] >>= shouldBeSuccess
-      mv "another_source_path/Main.purs" "src/Main.purs"
 
 
   describe "spago test" $ do
 
     it "Spago should test successfully" $ do
 
+      spago ["init"] >>= shouldBeSuccess
+      -- Note: apparently purs starts caching the compiled modules only after three builds
+      spago ["build"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
       spago ["test"] >>= shouldBeSuccessOutput "test-output.txt"
 
 
@@ -135,6 +141,10 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should run successfully" $ do
 
+      spago ["init"] >>= shouldBeSuccess
+      -- Note: apparently purs starts caching the compiled modules only after three builds
+      spago ["build"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
       spago ["run", "--verbose"] >>= shouldBeSuccessOutput "run-output.txt"
 
 
@@ -142,15 +152,14 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should fail but should point to the replacement command" $ do
 
-      spago ["bundle", "--to", "bundle.js"]
-        >>= shouldBeFailureOutput "bundle-output.txt"
+      spago ["bundle", "--to", "bundle.js"] >>= shouldBeFailureOutput "bundle-output.txt"
 
 
   describe "spago bundle-app" $ do
 
     it "Spago should bundle successfully" $ do
-      -- Remove output to ensure bundle builds as well as bundles
-      rmtree "output"
+
+      spago ["init"] >>= shouldBeSuccess
       spago ["bundle-app", "--to", "bundle-app.js"] >>= shouldBeSuccess
       checkFixture "bundle-app.js"
 
@@ -159,16 +168,17 @@ spec = beforeAll clean $ around_ (withCwd testDir) $ do
 
     it "Spago should fail but should point to the replacement command" $ do
 
-      spago ["make-module", "--to", "make-module.js"]
-        >>= shouldBeFailureOutput "make-module-output.txt"
+      spago ["make-module", "--to", "make-module.js"] >>= shouldBeFailureOutput "make-module-output.txt"
 
 
   describe "spago bundle-module" $ do
 
     it "Spago should successfully make a module" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
       -- Now we don't remove the output folder, but we pass the `--no-build`
       -- flag to skip rebuilding (i.e. we are counting on the previous command
       -- to have built stuff for us)
-      spago ["bundle-module", "--to", "bundle-module.js", "--no-build"]
-        >>= shouldBeSuccess
+      spago ["bundle-module", "--to", "bundle-module.js", "--no-build"] >>= shouldBeSuccess
       checkFixture "bundle-module.js"

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -35,7 +35,10 @@ runFor us cmd args = do
   Process.terminateProcess p
 
 shouldBeSuccess :: (ExitCode, Text, Text) -> IO ()
-shouldBeSuccess (code, _, _) = code `shouldBe` ExitSuccess
+shouldBeSuccess (code, _stdout, _stderr) = do
+  -- print $ "STDOUT: " <> _stdout
+  -- print $ "STDERR: " <> _stderr
+  code `shouldBe` ExitSuccess
 
 shouldBeSuccessOutput :: FilePath -> (ExitCode, Text, Text) -> IO ()
 shouldBeSuccessOutput expected (code, out, _) = do
@@ -43,7 +46,10 @@ shouldBeSuccessOutput expected (code, out, _) = do
   (code, out) `shouldBe` (ExitSuccess, expectedContent)
 
 shouldBeFailure :: (ExitCode, Text, Text) -> IO ()
-shouldBeFailure (code, _, _) = code`shouldBe` ExitFailure 1
+shouldBeFailure (code, _stdout, _stderr) = do
+  -- print $ "STDOUT: " <> _stdout
+  -- print $ "STDERR: " <> _stderr
+  code`shouldBe` ExitFailure 1
 
 shouldBeFailureOutput :: FilePath -> (ExitCode, Text, Text) -> IO ()
 shouldBeFailureOutput expected (code, _, out) = do

--- a/test/fixtures/spago-install-failure.dhall
+++ b/test/fixtures/spago-install-failure.dhall
@@ -5,7 +5,7 @@ You can edit this file as you like.
 { name =
     "aaa"
 , dependencies =
-    [ "effect", "console", "psci-support" ]
+    [ "console", "effect", "prelude", "psci-support" ]
 , packages =
     ./packages.dhall
 }

--- a/test/fixtures/spago-install-success.dhall
+++ b/test/fixtures/spago-install-success.dhall
@@ -5,7 +5,7 @@ You can edit this file as you like.
 { name =
     "aaa"
 , dependencies =
-    [ "console", "effect", "foreign", "psci-support", "simple-json" ]
+    [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
 , packages =
     ./packages.dhall
 }


### PR DESCRIPTION
Fix #214 

Now every testcase is run in a separate temp directory, thus not depending on the previous test environment
