### PR TITLE
Add option to clear the screen to spago build/run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.4] - 2019-06-11
 
+New features:
+- Add option to clear the screen to spago build/run (#209)
+
 Bugfixes:
 - Produce an error message when asserting directory permissions (#250)
 - Read purs version from inside the set instead of its GitHub tag (#253, #225)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ you can use the `--watch` flag:
 
 ```bash
 $ spago build --watch
+
+# or, to clear the screen on rebuild:
+$ spago build --watch --clear-screen
 ```
 
 If you want to run the program (akin to `pulp run`), just use `run`:

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -19,6 +19,7 @@ import           Spago.Messages      as Messages
 import           Spago.Packages      (PackageName (..), PackagesFilter (..), JsonFlag(..))
 import qualified Spago.Packages
 import qualified Spago.PscPackage    as PscPackage
+import           Spago.Watch        (ClearScreen (..))
 
 
 -- | Commands that this program handles
@@ -110,15 +111,21 @@ parser = do
   command <- projectCommands <|> packageSetCommands <|> pscPackageCommands <|> otherCommands <|> oldCommands
   pure (command, opts)
   where
-    force       = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
-    verbose     = CLI.switch "verbose" 'v' "Enable additional debug logging, e.g. printing `purs` commands"
-    watchBool   = CLI.switch "watch" 'w' "Watch for changes in local files and automatically rebuild"
-    noBuildBool = CLI.switch "no-build" 's' "Skip build step"
+    force           = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
+    verbose         = CLI.switch "verbose" 'v' "Enable additional debug logging, e.g. printing `purs` commands"
+    watchBool       = CLI.switch "watch" 'w' "Watch for changes in local files and automatically rebuild"
+    clearScreenBool = CLI.switch "clear-screen" 'l' "Clear the screen on rebuild (watch mode only)"
+    noBuildBool     = CLI.switch "no-build" 's' "Skip build step"
     watch = do
       res <- watchBool
       pure $ case res of
         True  -> Watch
         False -> BuildOnce
+    clearScreen = do
+      res <- clearScreenBool
+      pure $ case res of
+        True  -> DoClear
+        False -> NoClear
     noBuild = do
       res <- noBuildBool
       pure $ case res of
@@ -143,7 +150,7 @@ parser = do
     packageName = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames = CLI.many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     passthroughArgs = many $ CLI.arg (Just . ExtraArg) " ..any `purs compile` option" "Options passed through to `purs compile`; use -- to separate"
-    buildOptions = BuildOptions <$> limitJobs <*> cacheFlag <*> watch <*> sourcePaths <*> passthroughArgs
+    buildOptions = BuildOptions <$> limitJobs <*> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> passthroughArgs
     globalOptions = GlobalOptions <$> verbose
     packagesFilter =
       let wrap = \case

--- a/package.yaml
+++ b/package.yaml
@@ -76,6 +76,7 @@ library:
   - foldl
   - http-conduit
   - time
+  - ansi-terminal
 
 executables:
   spago:

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -41,6 +41,7 @@ data BuildOptions = BuildOptions
   { maybeLimit      :: Maybe Int
   , cacheConfig     :: Maybe GlobalCache.CacheFlag
   , shouldWatch     :: Watch
+  , shouldClear     :: Watch.ClearScreen
   , sourcePaths     :: [Purs.SourcePath]
   , passthroughArgs :: [Purs.ExtraArg]
   }
@@ -79,7 +80,7 @@ build BuildOptions{..} maybePostBuild = do
   absoluteProjectGlobs <- traverse makeAbsolute $ Text.unpack . Purs.unSourcePath <$> projectGlobs
   case shouldWatch of
     BuildOnce -> buildAction
-    Watch     -> Watch.watch (Set.fromAscList $ fmap Glob.compile absoluteProjectGlobs) buildAction
+    Watch     -> Watch.watch (Set.fromAscList $ fmap Glob.compile absoluteProjectGlobs) shouldClear buildAction
 
 -- | Start a repl
 repl :: Spago m => [Purs.SourcePath] -> [Purs.ExtraArg] -> m ()


### PR DESCRIPTION
### Description of the change

Fix #209 

Watch mode only argument --clear-screen (-l) clears the screen on every rebuild.
```bash
$ spago run -w -l
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
