### PR TITLE
Add sources to config

### DIFF
--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -45,12 +45,6 @@ data BuildOptions = BuildOptions
   , passthroughArgs :: [Purs.ExtraArg]
   }
 
-defaultSourcePaths :: [Purs.SourcePath]
-defaultSourcePaths =
-  [ Purs.SourcePath "src/**/*.purs"
-  , Purs.SourcePath "test/**/*.purs"
-  ]
-
 prepareBundleDefaults
   :: Maybe Purs.ModuleName
   -> Maybe Purs.TargetPath
@@ -69,7 +63,7 @@ build BuildOptions{..} maybePostBuild = do
   config@Config.Config{ packageSet = PackageSet.PackageSet{..}, ..} <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
   Fetch.fetchPackages maybeLimit cacheConfig deps packagesMinPursVersion
-  let projectGlobs = defaultSourcePaths <> sourcePaths
+  let projectGlobs = configSourcePaths <> sourcePaths
       allGlobs = Packages.getGlobs deps <> projectGlobs
       buildAction = do
         Purs.compile allGlobs passthroughArgs
@@ -87,7 +81,7 @@ repl sourcePaths passthroughArgs = do
   echoDebug "Running `spago repl`"
   config <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
-  let globs = Packages.getGlobs deps <> defaultSourcePaths <> sourcePaths
+  let globs = Packages.getGlobs deps <> Config.configSourcePaths config <> sourcePaths
   Purs.repl globs passthroughArgs
 
 -- | Test the project: compile and run "Test.Main"
@@ -170,4 +164,4 @@ docs sourcePaths = do
   config <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
   echo "Generating documentation for the project. This might take a while.."
-  Purs.docs $ defaultSourcePaths <> Packages.getGlobs deps <> sourcePaths
+  Purs.docs $ Config.configSourcePaths config <> Packages.getGlobs deps <> sourcePaths

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 module Spago.Config
   ( makeConfig
   , ensureConfig
@@ -21,6 +22,7 @@ import qualified Spago.Dhall        as Dhall
 import qualified Spago.Messages     as Messages
 import qualified Spago.PackageSet   as PackageSet
 import qualified Spago.PscPackage   as PscPackage
+import qualified Spago.Purs         as Purs
 import qualified Spago.Templates    as Templates
 
 import           Spago.PackageSet   (Package, PackageName, PackageSet)
@@ -36,9 +38,10 @@ path = pathFromText pathText
 
 -- | Spago configuration file type
 data Config = Config
-  { name         :: Text
-  , dependencies :: [PackageName]
-  , packageSet   :: PackageSet
+  { name              :: Text
+  , dependencies      :: [PackageName]
+  , packageSet        :: PackageSet
+  , configSourcePaths :: [Purs.SourcePath]
   } deriving (Show, Generic)
 
 type Expr = Dhall.DhallExpr Dhall.Import
@@ -46,18 +49,21 @@ type Expr = Dhall.DhallExpr Dhall.Import
 -- | Tries to read in a Spago Config
 parseConfig :: Spago m => m Config
 parseConfig = do
+  withConfigAST $ pure . addSourcePaths
   expr <- liftIO $ Dhall.inputExpr $ "./" <> pathText
   case expr of
     Dhall.RecordLit ks -> do
       maybeConfig <- pure $ do
         let packageTyp      = Dhall.genericAuto :: Dhall.Type Package
             packageNamesTyp = Dhall.list (Dhall.auto :: Dhall.Type PackageName)
+            sourcesType     = Dhall.list (Dhall.auto :: Dhall.Type Purs.SourcePath)
         name         <- Dhall.requireTypedKey ks "name" Dhall.strictText
         dependencies <- Dhall.requireTypedKey ks "dependencies" packageNamesTyp
         packages     <- Dhall.requireKey ks "packages" $ \case
           Dhall.RecordLit pkgs -> (Map.mapKeys PackageSet.PackageName . Dhall.Map.toMap)
             <$> traverse (Dhall.coerceToType packageTyp) pkgs
           something -> Left $ Dhall.PackagesIsNotRecord something
+        configSourcePaths  <- Dhall.requireTypedKey ks "sources" sourcesType
 
         let metadataPackageName = PackageSet.PackageName "metadata"
             (metadataMap, packagesDB) = Map.partitionWithKey (\k _v -> k == metadataPackageName) packages
@@ -150,6 +156,15 @@ addRawDeps config newPackages r@(Dhall.RecordLit kvs)
         seens = Seq.scanl (flip Set.insert) Set.empty xs
 addRawDeps _ _ other = pure other
 
+addSourcePaths :: Expr -> Expr
+addSourcePaths (Dhall.RecordLit kvs)
+  | isConfigV1 kvs = Dhall.RecordLit
+    $ Dhall.Map.insert "sources" (Dhall.ListLit Nothing $ fmap Dhall.toTextLit $ Seq.fromList ["src/**/*.purs", "test/**/*.purs"]) kvs
+  where
+    isConfigV1 (Set.fromList . Dhall.Map.keys -> configKeySet) =
+      let configV1Keys = Set.fromList ["name", "dependencies", "packages"]
+      in configKeySet == configV1Keys
+addSourcePaths expr = expr
 
 -- | Takes a function that manipulates the Dhall AST of the Config, and tries to run it
 --   on the current config. If it succeeds, it writes back to file the result returned.

--- a/src/Spago/Dhall.hs
+++ b/src/Spago/Dhall.hs
@@ -12,9 +12,9 @@ import qualified Data.Text.Prettyprint.Doc.Render.Text as PrettyText
 import           Dhall
 import           Dhall.Core                            as Dhall hiding (Type, pretty)
 import qualified Dhall.Format
+import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Parser                          as Parser
-import qualified Dhall.Import
 import qualified Dhall.Pretty
 import           Dhall.TypeCheck                       (X, typeOf)
 
@@ -56,7 +56,6 @@ writeRawExpr pathText (header, expr) = do
   -- if it doesn't we don't write to file.
   resolvedExpr <- Dhall.Import.load expr
   throws (Dhall.TypeCheck.typeOf resolvedExpr)
-  echo $ "Done. Updating the \"" <> pathText <> "\" file.."
   writeTextFile (pathFromText pathText) $ prettyWithHeader header expr <> "\n"
   format pathText
 

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -4,6 +4,7 @@ import           Spago.Prelude
 
 import qualified Data.Text      as Text
 import           Data.Versions  as Version
+import qualified Spago.Dhall    as Dhall
 
 import qualified Spago.Messages as Messages
 
@@ -11,6 +12,7 @@ import qualified Spago.Messages as Messages
 newtype ModuleName = ModuleName { unModuleName :: Text }
 newtype TargetPath = TargetPath { unTargetPath :: Text }
 newtype SourcePath = SourcePath { unSourcePath :: Text }
+  deriving newtype (Show, Dhall.Interpret)
 newtype ExtraArg = ExtraArg { unExtraArg :: Text }
 
 data WithMain = WithMain | WithoutMain

--- a/templates/spago.dhall
+++ b/templates/spago.dhall
@@ -8,4 +8,6 @@ You can edit this file as you like.
     [ "effect", "console", "psci-support" ]
 , packages =
     ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -6,8 +6,9 @@ import qualified System.IO.Temp     as Temp
 import           Test.Hspec         (Spec, around_, describe, it, shouldBe)
 import           Turtle             (cp, decodeString, mkdir, mktree, mv, readTextFile, testdir,
                                      writeTextFile)
-import           Utils              (checkFixture, runFor, shouldBeFailure, shouldBeFailureOutput,
-                                     shouldBeSuccess, shouldBeSuccessOutput, spago, withCwd)
+import           Utils              (checkFixture, readFixture, runFor, shouldBeFailure,
+                                     shouldBeFailureOutput, shouldBeSuccess, shouldBeSuccessOutput,
+                                     spago, withCwd)
 
 
 setup :: IO () -> IO ()
@@ -125,6 +126,14 @@ spec = around_ setup $ do
       mv "src/Main.purs" "another_source_path/Main.purs"
       spago ["build", "--path", "another_source_path/*.purs"] >>= shouldBeSuccess
 
+    it "Spago should add sources to config when key is missing" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      -- Replace initial config with the old config format (without 'sources')
+      writeTextFile "spago.dhall" =<< readFixture "spago-configV1.dhall"
+      spago ["build"] >>= shouldBeSuccess
+      mv "spago.dhall" "spago-configV2.dhall"
+      checkFixture "spago-configV2.dhall"
 
   describe "spago test" $ do
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,5 +1,6 @@
 module Utils
   ( checkFixture
+  , readFixture
   , rmtree
   , runFor
   , shouldBeFailure
@@ -16,8 +17,8 @@ import           Prelude            hiding (FilePath)
 import           System.Directory   (removePathForcibly)
 import qualified System.Process     as Process
 import           Test.Hspec         (shouldBe)
-import           Turtle             (ExitCode (..), FilePath, Text, cd, empty,
-                                     encodeString, procStrictWithErr, pwd, readTextFile)
+import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString,
+                                     procStrictWithErr, pwd, readTextFile)
 
 withCwd :: FilePath -> IO () -> IO ()
 withCwd dir cmd = do

--- a/test/fixtures/spago-configV1.dhall
+++ b/test/fixtures/spago-configV1.dhall
@@ -1,0 +1,11 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+    "aaa"
+, dependencies =
+    [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
+, packages =
+    ./packages.dhall
+}

--- a/test/fixtures/spago-configV2.dhall
+++ b/test/fixtures/spago-configV2.dhall
@@ -1,0 +1,13 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
+, name =
+    "aaa"
+, dependencies =
+    [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
+, packages =
+    ./packages.dhall
+}

--- a/test/fixtures/spago-install-failure.dhall
+++ b/test/fixtures/spago-install-failure.dhall
@@ -8,4 +8,6 @@ You can edit this file as you like.
     [ "console", "effect", "prelude", "psci-support" ]
 , packages =
     ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-install-success.dhall
+++ b/test/fixtures/spago-install-success.dhall
@@ -8,4 +8,6 @@ You can edit this file as you like.
     [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
 , packages =
     ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-psc-failure.dhall
+++ b/test/fixtures/spago-psc-failure.dhall
@@ -8,4 +8,6 @@ You can edit this file as you like.
     [ "effect", "console", "psci-support" ]
 , packages =
     ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-psc-success.dhall
+++ b/test/fixtures/spago-psc-success.dhall
@@ -8,4 +8,6 @@ You can edit this file as you like.
     [ "console", "effect", "prelude", "psci-support" ]
 , packages =
     ./packages.dhall
+, sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
 }


### PR DESCRIPTION
### Description of the change

Add key `sources` to config (fix #173)
Default source paths are `[ "src/**/*.purs", "test/**/*.purs" ]`.


