### PR TITLE
Add option to pass arguments to node on test/run (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bugfixes:
 
 New features:
 - Add option to clear the screen to spago build/run (#209)
+- Add option to pass args to node when doing spago test/run (#267)
 
 Bugfixes:
 - Produce an error message when asserting directory permissions (#250)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ $ spago run --main ModulePath.To.Main
 
 # And pass arguments through to `purs compile`
 $ spago run --main ModulePath.To.Main -- --verbose-errors
+
+# Or pass arguments to node
+$ spago run --node-args "arg1 arg2"
 ```
 
 

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -87,12 +87,12 @@ repl sourcePaths passthroughArgs = do
 
 -- | Test the project: compile and run "Test.Main"
 --   (or the provided module name) with node
-test :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> m ()
+test :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> [Purs.ExtraArg] -> m ()
 test = runWithNode (Purs.ModuleName "Test.Main") (Just "Tests succeeded.") "Tests failed: "
 
 -- | Run the project: compile and run "Main"
 --   (or the provided module name) with node
-run :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> m ()
+run :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> [Purs.ExtraArg] -> m ()
 run = runWithNode (Purs.ModuleName "Main") Nothing "Running failed, exit code: "
 
 -- | Run the project with node: compile and run with the provided ModuleName
@@ -104,13 +104,15 @@ runWithNode
   -> Text
   -> Maybe Purs.ModuleName
   -> BuildOptions
+  -> [Purs.ExtraArg]
   -> m ()
-runWithNode defaultModuleName maybeSuccessMessage failureMessage maybeModuleName buildOpts = do
+runWithNode defaultModuleName maybeSuccessMessage failureMessage maybeModuleName buildOpts nodeArgs = do
   echoDebug "Running NodeJS"
   build buildOpts (Just nodeAction)
   where
     moduleName = fromMaybe defaultModuleName maybeModuleName
-    cmd = "node -e \"require('./output/" <> Purs.unModuleName moduleName <> "').main()\""
+    args = Text.intercalate " " $ map Purs.unExtraArg nodeArgs
+    cmd = "node -e \"require('./output/" <> Purs.unModuleName moduleName <> "').main()\" " <> args
     nodeAction = do
       shell cmd empty >>= \case
         ExitSuccess   -> fromMaybe (pure ()) (echo <$> maybeSuccessMessage)


### PR DESCRIPTION
### Description of the change

First pass at --node-args (fix #267)

```bash
$ spago run
Installation complete.
Build succeeded.
["/usr/bin/node"]
$ spago run -n "foo bar"
Installation complete.
Build succeeded.
["/usr/bin/node","foo","bar"]
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

