### PR TITLE
Handle branch names differing only by case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Fix `spago install` failing when version branch names differ only by case on case-insensitive filesystems (#258)
+
 ## [0.8.5] - 2019-06-18
 
 ZuriHac edition 🎉

--- a/package.yaml
+++ b/package.yaml
@@ -134,3 +134,7 @@ tests:
     - directory
     - temporary
     - extra
+    - containers
+    - QuickCheck
+    - spago
+    - extra

--- a/package.yaml
+++ b/package.yaml
@@ -138,4 +138,3 @@ tests:
     - containers
     - QuickCheck
     - spago
-    - extra

--- a/test/UnitSpec.hs
+++ b/test/UnitSpec.hs
@@ -1,0 +1,96 @@
+-- Unit tests
+module UnitSpec where
+
+import Prelude
+import Data.List.Extra (nubOrd)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Map as Map
+import Test.QuickCheck (Gen, Property)
+import qualified Test.QuickCheck as QC
+import Test.Hspec (Spec, describe, it)
+
+import Spago.FetchPackage (getCacheVersionDir)
+
+-- A value of this type represents a failure of a function to be injective,
+-- specifically, that all of the distinct values in the `inputs` list each
+-- mapped to the same output.
+data InjectivityFailure a b
+  = InjectivityFailure
+      { inputs :: [a]
+        -- ^ should all be distinct and should have at least 2 elements.
+      , allMapTo :: b
+      }
+  deriving (Eq, Ord, Show)
+
+-- | Given a generator some type, return a new generator which returns a list
+-- of that type, with the given length, where all elements are distinct.
+uniqVectorOf :: Ord a => Int -> Gen a -> Gen [a]
+uniqVectorOf count gen =
+  fmap (take count . nubOrd) (QC.infiniteListOf gen)
+
+-- | Randomly resize a generator up to the provided maximum size.
+randomlyResize :: Int -> Gen a -> Gen a
+randomlyResize maxSize gen = do
+  size <- QC.choose (1, maxSize)
+  QC.resize size gen
+
+checkInjective :: forall a b. (Ord a, Ord b, Show a, Show b) => (a -> b) -> Gen a -> Property
+checkInjective f gen =
+  QC.once $
+    fmap check $
+      -- Generate a lot of distinct inputs of various (small) sizes
+      uniqVectorOf countInputs $
+        randomlyResize maxSize gen
+
+  where
+  maxSize = 5
+  countInputs = 50000
+
+  check :: [a] -> Property
+  check inputs =
+    let
+      collisions = findCollisions inputs
+      maxCounterexamples = 10
+    in
+      if null collisions
+        then
+          QC.property True
+        else
+          let
+            numCollisions = length collisions
+            msgPrefix = concat
+              [ "Showing "
+              , if numCollisions <= maxCounterexamples
+                  then "all"
+                  else show maxCounterexamples
+              , " of the "
+              , show numCollisions
+              , " counterexamples:\n"
+              ]
+          in
+            QC.counterexample
+              (msgPrefix ++ unlines (map show (take maxCounterexamples collisions)))
+              False
+
+  findCollisions :: [a] -> [InjectivityFailure a b]
+  findCollisions =
+    map (uncurry (flip InjectivityFailure))
+    . Map.toList
+    . Map.filter (\xs -> length xs > 1)
+    . Map.fromListWith (++)
+    . map (\x -> (f x, [x]))
+
+-- This needs to be a small generator if we want collisions to come up
+genBranchName :: Gen Text
+genBranchName =
+  fmap mconcat $ QC.listOf1 $ QC.elements $
+    [ "/" , "\\" , ":" , ";" , "%" ]
+    ++ map Text.singleton [ 'A' .. 'F' ]
+    ++ map Text.singleton [ 'a' .. 'f' ]
+    ++ map Text.singleton [ '0' .. '9' ]
+
+spec :: Spec
+spec = describe "unit tests" $ do
+  it "getCacheVersionDir is (case insensitively) injective" $
+    checkInjective (Text.toLower . getCacheVersionDir) genBranchName


### PR DESCRIPTION
### Description of the change

Escape upper case characters in branch names to ensure that branches
which only differ in case don't cause issues on case-insensitive file
systems.

Also switch to using an allowlist for escaping characters: it seems a
little safer to specify the characters which don't need escaping (and to
escape everything else), than to specify characters which do need
escaping.

Finally, add a test that `getCacheVersionDir` is injective.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] ~~Added some example of the new feature to the `README`~~
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
