### PR TITLE
Add `--format` flag to `spago docs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 
 New features:
 - Add support for starting a repl within a folder which has not been setup as a spago project (#168)
+- Add `--format` flag to `spago docs` (#294)
 
 ## [0.8.5] - 2019-06-18
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,12 @@ $ spago docs
 This will generate all the documentation in the `./generated-docs` folder of your project.
 You might then want to open the `index.html` file in there.
 
+To build the documentation as Markdown instead of HTML, or to generate tags for your project,
+you can pass a `format` flag:
+```bash
+$ spago docs --format ctags
+```
+
 
 ### Publish my library
 

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -194,10 +194,10 @@ bundleModule maybeModuleName maybeTargetPath noBuild buildOpts = do
     NoBuild -> bundleAction
 
 -- | Generate docs for the `sourcePaths`
-docs :: Spago m => [Purs.SourcePath] -> m ()
-docs sourcePaths = do
+docs :: Spago m => Maybe Purs.DocsFormat -> [Purs.SourcePath] -> m ()
+docs format sourcePaths = do
   echoDebug "Running `spago docs`"
   config <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
   echo "Generating documentation for the project. This might take a while.."
-  Purs.docs $ Config.configSourcePaths config <> Packages.getGlobs deps <> sourcePaths
+  Purs.docs format $ Config.configSourcePaths config <> Packages.getGlobs deps <> sourcePaths

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -54,11 +54,34 @@ bundle withMain (ModuleName moduleName) (TargetPath targetPath) = do
     ("Bundle failed.")
 
 
-docs :: Spago m => [SourcePath] -> m ()
-docs sourcePaths = do
+data DocsFormat
+  = Html
+  | Markdown
+  | Ctags
+  | Etags
+
+parseDocsFormat :: Text -> Maybe DocsFormat
+parseDocsFormat = \case
+  "html"     -> Just Html
+  "markdown" -> Just Markdown
+  "ctags"    -> Just Ctags
+  "etags"    -> Just Etags
+  _          -> Nothing
+
+printDocsFormat :: DocsFormat -> Text
+printDocsFormat = \case
+  Html     -> "html"
+  Markdown -> "markdown"
+  Ctags    -> "ctags"
+  Etags    -> "etags"
+
+
+docs :: Spago m => Maybe DocsFormat -> [SourcePath] -> m ()
+docs format sourcePaths = do
   let
     paths = Text.intercalate " " $ Messages.surroundQuote <$> map unSourcePath sourcePaths
-    cmd = "purs docs " <> paths <> " --format html"
+    formatStr = printDocsFormat $ fromMaybe Html format
+    cmd = "purs docs " <> paths <> " --format " <> formatStr
   runWithOutput cmd
     ("Docs generated. Index is at " <> Messages.surroundQuote "./generated-docs/index.html")
     "Docs generation failed."

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -83,7 +83,7 @@ docs format sourcePaths = do
     formatStr = printDocsFormat $ fromMaybe Html format
     cmd = "purs docs " <> paths <> " --format " <> formatStr
   runWithOutput cmd
-    ("Docs generated. Index is at " <> Messages.surroundQuote "./generated-docs/index.html")
+    "Docs generation succeeded."
     "Docs generation failed."
 
 version :: Spago m => m (Maybe Version.SemVer)


### PR DESCRIPTION
### Description of the change

Add a flag to `spago docs` to support different documentation formats. Fixes #294.

Running `stack test` on `master` seems to lead to about half the tests failing, so I can't verify that these changes haven't broken them further.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
