### PR TITLE
Add fallback for global cache directory

### DIFF
--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -157,7 +157,7 @@ getMetadata cacheFlag = do
 getGlobalCacheDir :: Spago m => m FilePath.FilePath
 getGlobalCacheDir = do
   echoDebug "Running `getGlobalCacheDir`"
-  cacheDir <- alternative₀ <|> alternative₁ <|> alternative₂ <|> err
+  cacheDir <- alternative₀ <|> alternative₁ <|> alternative₂ <|> alternative₃ <|> err
   pure $ cacheDir </> "spago"
   where
     err = die Messages.cannotGetGlobalCacheDir
@@ -177,7 +177,14 @@ getGlobalCacheDir = do
         Just homeDirectory -> return (homeDirectory </> ".cache")
         Nothing            -> empty
 
-    alternative₂ = pure ".spago-global-cache"
+    alternative₂ = do
+      maybeWindowsHomeDirectory <- liftIO (System.Environment.lookupEnv "HomePath")
+
+      case maybeWindowsHomeDirectory of
+        Just homeDirectory -> return (homeDirectory </> ".cache")
+        Nothing            -> empty
+
+    alternative₃ = pure ".spago-global-cache"
 
 
 -- | Fetch the tarball at `archiveUrl` and unpack it into `destination`

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -14,6 +14,7 @@ import qualified System.Environment
 import qualified System.FilePath        as FilePath
 import qualified Turtle
 
+import qualified Spago.Messages         as Messages
 import           Spago.PackageSet       (PackageName (..))
 
 
@@ -147,16 +148,19 @@ getMetadata cacheFlag = do
 
 
 -- | Directory in which spago will put its global cache
--- | Code from: https://github.com/dhall-lang/dhall-haskell/blob/d8f2787745bb9567a4542973f15e807323de4a1a/dhall/src/Dhall/Import.hs#L578
+--   Code from: https://github.com/dhall-lang/dhall-haskell/blob/d8f2787745bb9567a4542973f15e807323de4a1a/dhall/src/Dhall/Import.hs#L578
+--
+--   In order we try to get:
+--   - the folder pointed by `$XDG_CACHE_HOME`
+--   - the folder pointed by `$HOME/.cache`
+--   - the project-local `.cache`
 getGlobalCacheDir :: Spago m => m FilePath.FilePath
 getGlobalCacheDir = do
   echoDebug "Running `getGlobalCacheDir`"
-  cacheDir <- alternative₀ <|> alternative₁ <|> err
+  cacheDir <- alternative₀ <|> alternative₁ <|> alternative₂ <|> err
   pure $ cacheDir </> "spago"
   where
-    err = do
-      echo "Error: was not able to get a directory for the global cache. Set either `HOME` or `XDG_CACHE_HOME`"
-      empty
+    err = die Messages.cannotGetGlobalCacheDir
 
     alternative₀ = do
       maybeXDGCacheHome <- do
@@ -172,6 +176,8 @@ getGlobalCacheDir = do
       case maybeHomeDirectory of
         Just homeDirectory -> return (homeDirectory </> ".cache")
         Nothing            -> empty
+
+    alternative₂ = pure ".spago-global-cache"
 
 
 -- | Fetch the tarball at `archiveUrl` and unpack it into `destination`

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -26,6 +26,17 @@ cannotFindPackagesButItsFine = makeMessage
   [ "WARNING: did not find a " <> surroundQuote "packages.dhall" <> " in your current location, skipping compiler version check"
   ]
 
+cannotGetGlobalCacheDir :: Text
+cannotGetGlobalCacheDir = makeMessage
+  [ "ERROR: Spago was not able to get a directory for the global cache. To fix this there are some things you could do:"
+  , ""
+  , "- Set either the `HOME` or `XDG_CACHE_HOME` environment variable. Depending on your OS you'll have to type a different thing in your terminal to do it:"
+  , "  On Windows:    set XDG_CACHE_DIR=\"C:\\tmp\\spago\""
+  , "  On Linux/Mac:  export XDG_CACHE_HOME='/tmp/spago'"
+  , ""
+  , "- Disable the global cache entirely, by passing to Spago `--global-cache skip`"
+  ]
+
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage
   [ "Found a " <> surroundQuote pathText <> " file, skipping copy. Run `spago init --force` if you wish to overwrite it."


### PR DESCRIPTION
Fix #312 

Sometimes on Windows it was not possible to get a directory to put a global cache, so here we fix that by:
- if all previous check fail, we try reading the directory in the `HomePath` environment variable
- if that fails we just make a `.spago-global-cache` folder in the current directory
- if we decide to get rid of the previous option because it's not good for some reason, I made the error message nice anyways
