### PR TITLE
Remove mkPackage Dhall function and switch to package-sets releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,22 +480,22 @@ E.g. if we want to add the `facebook` package:
 ```haskell
 let additions =
   { facebook =
-      mkPackage
-        [ "console"
-        , "aff"
-        , "prelude"
-        , "foreign"
-        , "foreign-generic"
-        , "errors"
-        , "effect"
-        ]
-        "https://github.com/Unisay/purescript-facebook.git"
-        "v0.3.0"
+      { dependencies =
+          [ "console"
+          , "aff"
+          , "prelude"
+          , "foreign"
+          , "foreign-generic"
+          , "errors"
+          , "effect"
+          ]
+      , repo =
+          "https://github.com/Unisay/purescript-facebook.git"
+      , version =
+          "v0.3.0"
+      }
   }
 ```
-
-The `mkPackage` function should be already included in your `packages.dhall`, and it will
-expect as input a list of dependencies, the location of the package, and the tag you wish to use.
 
 Of course this works also in the case of adding local packages. In this case you won't
 care about the value of the "version" (since it won't be used), so you can put arbitrary

--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -265,8 +265,11 @@ packageSetsUpdater token dataChan = go mempty mempty
   where
     updateVersion :: Monad m => PackageName -> Tag -> Expr -> m Expr
     updateVersion (PackageName packageName) (Tag tag) (Dhall.RecordLit kvs)
-      | Just (Dhall.App rest@(Dhall.App (Dhall.App (Dhall.Var (Dhall.V "mkPackage" 0)) _deps) _repo) (Dhall.TextLit _)) <- Dhall.Map.lookup packageName kvs =
-          let newPackage = Dhall.App rest $ Dhall.toTextLit tag
+      | Just (Dhall.RecordLit pkgKVs) <- Dhall.Map.lookup packageName kvs
+      , Just (Dhall.TextLit _) <- Dhall.Map.lookup "version" pkgKVs =
+          let
+            newPackageVersion = Dhall.toTextLit tag
+            newPackage = Dhall.RecordLit $ Dhall.Map.insert "version" newPackageVersion pkgKVs
           in pure $ Dhall.RecordLit $ Dhall.Map.insert packageName newPackage kvs
     updateVersion _ _ other = pure other
 

--- a/package.yaml
+++ b/package.yaml
@@ -59,7 +59,6 @@ library:
   - async-pool
   - process
   - network-uri
-  - github
   - versions
   - lens
   - safe
@@ -75,6 +74,7 @@ library:
   - zlib
   - tar
   - foldl
+  - http-client
   - http-conduit
   - time
   - ansi-terminal

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -125,6 +125,23 @@ upgradePackageSet = do
       { importHashed = Dhall.ImportHashed
         { importType = Dhall.Remote Dhall.URL
           -- Check if we're dealing with the right repo
+          { authority = "github.com"
+          , path = Dhall.File
+            { file = "packages.dhall"
+            , directory = Dhall.Directory
+              { components = [ currentTag, "download", "releases", "package-sets", "purescript" ]}
+            }
+          , ..
+          }
+        , ..
+        }
+      , ..
+      } = [currentTag]
+    -- TODO: remove this branch in 1.0
+    getCurrentTag Dhall.Import
+      { importHashed = Dhall.ImportHashed
+        { importType = Dhall.Remote Dhall.URL
+          -- Check if we're dealing with the right repo
           { authority = "raw.githubusercontent.com"
           , path = Dhall.File
             { directory = Dhall.Directory
@@ -142,13 +159,39 @@ upgradePackageSet = do
     -- | Given an import and a new purescript/package-sets tag,
     --   upgrades the import to the tag and resets the hash
     upgradeImports :: Text -> Dhall.Import -> Dhall.Import
+    upgradeImports newTag (Dhall.Import
+      { importHashed = Dhall.ImportHashed
+        { importType = Dhall.Remote Dhall.URL
+          { authority = "github.com"
+          , path = Dhall.File
+            { file = "packages.dhall"
+            , directory = Dhall.Directory
+              { components = [ _currentTag, "download", "releases", "package-sets", "purescript" ]}
+            , ..
+            }
+          , ..
+          }
+        , ..
+        }
+      , ..
+      }) =
+      let components = [ newTag, "download", "releases", "package-sets", "purescript" ]
+          directory = Dhall.Directory{..}
+          newPath = Dhall.File{ file = "packages.dhall", .. }
+          authority = "github.com"
+          importType = Dhall.Remote Dhall.URL { path = newPath, ..}
+          newHash = Nothing -- Reset the hash here, as we'll refreeze
+          importHashed = Dhall.ImportHashed { hash = newHash, ..}
+      in Dhall.Import{..}
+    -- TODO: remove this branch in 1.0
     upgradeImports newTag imp@(Dhall.Import
       { importHashed = Dhall.ImportHashed
         { importType = Dhall.Remote Dhall.URL
           -- Check if we're dealing with the right repo
           { authority = "raw.githubusercontent.com"
           , path = Dhall.File
-            { directory = Dhall.Directory
+            { file = "packages.dhall"
+            , directory = Dhall.Directory
               { components = [ "src", _currentTag, ghRepo, ghOrg ]}
             , ..
             }
@@ -158,10 +201,10 @@ upgradePackageSet = do
         }
       , ..
       }) =
-      let components = [ "src", newTag, "package-sets", "purescript" ]
+      let components = [ newTag, "download", "releases", "package-sets", "purescript" ]
           directory = Dhall.Directory{..}
-          newPath = Dhall.File{..}
-          authority = "raw.githubusercontent.com"
+          newPath = Dhall.File{ file = "packages.dhall", ..}
+          authority = "github.com"
           importType = Dhall.Remote Dhall.URL { path = newPath, ..}
           newHash = Nothing -- Reset the hash here, as we'll refreeze
           importHashed = Dhall.ImportHashed { hash = newHash, ..}

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -128,7 +128,8 @@ upgradePackageSet = do
     getLatestRelease = do
       request <- Http.parseRequest "https://github.com/purescript/package-sets/releases/latest"
       response <- Http.httpBS $ request { Http.redirectCount = 0 }
-      let [redirectUrl] = Http.getResponseHeader "Location" response
+      redirectUrl <- (\case [u] -> pure u; _ -> error ("Error following GitHub redirect, response:\n\n" <> show response))
+          $ Http.getResponseHeader "Location" response
       pure $ last $ Text.splitOn "/" $ Text.decodeUtf8 redirectUrl
 
     getCurrentTag :: Dhall.Import -> [Text]

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -65,19 +65,25 @@ Replace the additions' "{=}" (an empty record) with the following idea:
 -------------------------------
 let additions =
   { "package-name" =
-       mkPackage
-         [ "dependency1"
-         , "dependency2"
-         ]
-         "https://example.com/path/to/git/repo.git"
-         "tag ('v4.0.0') or branch ('master')"
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
   , "package-name" =
-       mkPackage
-         [ "dependency1"
-         , "dependency2"
-         ]
-         "https://example.com/path/to/git/repo.git"
-         "tag ('v4.0.0') or branch ('master')"
+       { dependencies =
+           [ "dependency1"
+           , "dependency2"
+           ]
+       , repo =
+           "https://example.com/path/to/git/repo.git"
+       , version =
+           "tag ('v4.0.0') or branch ('master')"
+       }
   , etc.
   }
 -------------------------------
@@ -86,33 +92,34 @@ Example:
 -------------------------------
 let additions =
   { benchotron =
-      mkPackage
-        [ "arrays"
-        , "exists"
-        , "profunctor"
-        , "strings"
-        , "quickcheck"
-        , "lcg"
-        , "transformers"
-        , "foldable-traversable"
-        , "exceptions"
-        , "node-fs"
-        , "node-buffer"
-        , "node-readline"
-        , "datetime"
-        , "now"
-        ]
-        "https://github.com/hdgarrood/purescript-benchotron.git"
-        "v7.0.0"
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ],
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
   }
 -------------------------------
 -}
 
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.2-20190715/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e
 
 let overrides = {=}
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -137,7 +137,7 @@ spec = around_ setup $ do
       spago ["init"] >>= shouldBeSuccess
       rm "spago.dhall"
       writeTextFile "spago.dhall" "{ name = \"app\", dependencies = [\"console\", \"effect\", \"prelude\", \"lib-a\", \"lib-b\"], packages = ./packages.dhall }"
-      writeTextFile "mkPackage" "λ(dependencies : List Text) → λ(repo : Text) → λ(version : Text) → { dependencies = dependencies, repo = repo, version = version }"
+      writeTextFile "mkPackage" "\\(dependencies : List Text) -> \\(repo : Text) -> \\(version : Text) -> { dependencies = dependencies, repo = repo, version = version }"
       packageDhall <- readTextFile "packages.dhall"
       writeTextFile "packages.dhall" $ packageDhall <> " // { lib-a = ./mkPackage ./lib-a/spago-deps.dhall \"./lib-a\" \"v1.0.0\", lib-b = ./mkPackage ./lib-b/spago-deps.dhall \"./lib-b\" \"v1.0.0\" }"
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -214,7 +214,7 @@ spec = around_ setup $ do
             $ Text.lines packages
       writeTextFile "packages.dhall" "https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e"
       spago ["package-set-upgrade"] >>= shouldBeSuccess
-      newPackages <- readTextFile "packages.dhall"
+      newPackages <- fmap Text.strip $ readTextFile "packages.dhall"
       newPackages `shouldBe` packageSetUrl
 
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -2,11 +2,12 @@ module SpagoSpec (spec) where
 
 import           Control.Concurrent (threadDelay)
 import           Data.Foldable      (for_)
+import qualified Data.Text          as Text
 import           Prelude            hiding (FilePath)
 import qualified System.IO.Temp     as Temp
 import           Test.Hspec         (Spec, around_, describe, it, shouldBe)
-import           Turtle             (cd, cp, decodeString, fromText, mkdir, mktree, mv, readTextFile,
-                                     rm, testdir, writeTextFile)
+import           Turtle             (cd, cp, decodeString, fromText, mkdir, mktree, mv,
+                                     readTextFile, rm, testdir, writeTextFile)
 import           Utils              (checkFixture, readFixture, runFor, shouldBeFailure,
                                      shouldBeFailureOutput, shouldBeSuccess, shouldBeSuccessOutput,
                                      spago, withCwd)
@@ -198,6 +199,23 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       spago ["build"] >>= shouldBeSuccess
       spago ["test"] >>= shouldBeSuccessOutput "test-output.txt"
+
+
+  describe "spago package-set-upgrade" $ do
+
+    it "Spago should migrate package-sets from src/packages.dhall to the released one" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      mv "packages.dhall" "packages-expected.dhall"
+      packages <- readTextFile "packages-expected.dhall"
+      let [packageSetUrl]
+            = map Text.strip
+            $ filter (not . null . Text.breakOnAll "https://github.com/purescript/package-sets")
+            $ Text.lines packages
+      writeTextFile "packages.dhall" "https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e"
+      spago ["package-set-upgrade"] >>= shouldBeSuccess
+      newPackages <- readTextFile "packages.dhall"
+      newPackages `shouldBe` packageSetUrl
 
 
   describe "spago run" $ do

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -137,8 +137,9 @@ spec = around_ setup $ do
       spago ["init"] >>= shouldBeSuccess
       rm "spago.dhall"
       writeTextFile "spago.dhall" "{ name = \"app\", dependencies = [\"console\", \"effect\", \"prelude\", \"lib-a\", \"lib-b\"], packages = ./packages.dhall }"
+      writeTextFile "mkPackage" "λ(dependencies : List Text) → λ(repo : Text) → λ(version : Text) → { dependencies = dependencies, repo = repo, version = version }"
       packageDhall <- readTextFile "packages.dhall"
-      writeTextFile "packages.dhall" $ packageDhall <> " // { lib-a = mkPackage ./lib-a/spago-deps.dhall \"./lib-a\" \"v1.0.0\", lib-b = mkPackage ./lib-b/spago-deps.dhall \"./lib-b\" \"v1.0.0\" }"
+      writeTextFile "packages.dhall" $ packageDhall <> " // { lib-a = ./mkPackage ./lib-a/spago-deps.dhall \"./lib-a\" \"v1.0.0\", lib-b = ./mkPackage ./lib-b/spago-deps.dhall \"./lib-b\" \"v1.0.0\" }"
 
       spago ["install"] >>= shouldBeSuccess
 


### PR DESCRIPTION
Upgrade to purescript/package-sets#399

Changes:
- remove `mkPackage` from template (fix #320) 
- switch to `packages.dhall` from releases (fix #319)

TODO:
- [x] Remove remaining references of `mkPackage` from README and tests
- [x] ~Wait for #301 to be merged~ update: we don't need to wait, but we'll need to be careful in there so that we don't miss references to `mkPackage`
- [x] Port `Curator` to the new format of `package-sets`
- [x] Add test for the migration
- [x] ~Add `dhall lint` invocation to remove unused bindings in `packages.dhall`~ EDIT: skipping this, so many corner cases
- [x] ~Add warning to remove `mkPackage` if we detect it somewhere~ EDIT: crawling the AST is lots of work, and just grepping has false positives. Giving up is fine, because the schema is backwards compatible.