### PR TITLE
Fix missing "commits since last release" in GH releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ before_deploy:
 deploy:
   - provider: releases
     api_key: $API_KEY
+    target_commitish: master
     file:
       - ../$TRAVIS_OS_NAME.tar.gz
     skip_cleanup: true


### PR DESCRIPTION
If you see [the latest release](https://github.com/spacchetti/spago/releases/tag/0.8.5.0) the message "X commits since release" is missing, and this should fix this according to GitHub Support and https://github.com/travis-ci/dpl/issues/934