### PR TITLE
Add docs search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test/spago-test
 *.cabal
 *~
 **/__pycache__
+templates/docs-search-app.js
+templates/purescript-docs-search

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -103,10 +103,11 @@ data Command
   -- | Deletes the .psc-package folder
   | PscPackageClean
 
+  -- | Runs `purescript-docs-search search`.
+  | Search
 
   -- | Show version
   | Version
-
 
   -- | Bundle the project into an executable (replaced by BundleApp)
   | Bundle
@@ -179,6 +180,7 @@ parser = do
       , bundleApp
       , bundleModule
       , docs
+      , search
       ]
 
     initProject =
@@ -229,6 +231,11 @@ parser = do
       , Docs <$> docsFormat <*> sourcePaths <*> depsOnly
       )
 
+    search =
+      ( "search"
+      , "Run the search engine."
+      , pure Search
+      )
 
     packageSetCommands = CLI.subcommandGroup "Package set commands:"
       [ install
@@ -377,5 +384,6 @@ main = do
       PscPackageLocalSetup force            -> liftIO $ PscPackage.localSetup force
       PscPackageInsDhall                    -> liftIO $ PscPackage.insDhall
       PscPackageClean                       -> liftIO $ PscPackage.clean
+      Search                                -> Spago.Build.search
       Bundle                                -> die Messages.bundleCommandRenamed
       MakeModule                            -> die Messages.makeModuleCommandRenamed

--- a/src/Spago/TH.hs
+++ b/src/Spago/TH.hs
@@ -2,13 +2,20 @@
 
 module Spago.TH
   ( embedFileUtf8
+  , embedURLWithFallback
   ) where
 
-import           Data.FileEmbed
-import           Data.Text.Encoding         as LT
-import           Language.Haskell.TH.Syntax (Exp, Q)
 import           Prelude
 
+import           Control.Exception           (try, SomeException)
+import           Data.ByteString             (ByteString)
+import           Data.FileEmbed
+import           Data.Text                   (unpack)
+import           Data.Text.Encoding          as LT
+import           Language.Haskell.TH.Syntax  (Exp(..), Q, runIO, Lit(StringL))
+import           Network.HTTP.Client.Conduit (parseUrlThrow)
+import           Network.HTTP.Simple         (httpBS, getResponseBody)
+import qualified Data.ByteString             as BS
 
 -- | This is here so that we can embed files as Utf8 Text.
 --   The reason for that is that since we have unicode Dhall files,
@@ -21,3 +28,23 @@ import           Prelude
 embedFileUtf8 :: FilePath -> Q Exp
 embedFileUtf8 filePath =
   [| LT.decodeUtf8 $(makeRelativeToProject filePath >>= embedFile) |]
+
+-- | Embed a file from a URL or use a local file as a fallback.
+--   If fetching the URL was successfull, write the contents to the fallback file.
+embedURLWithFallback
+  :: String
+  -- ^ A URL.
+  -> FilePath
+  -- ^ A fallback file.
+  -> Q Exp
+embedURLWithFallback url filePath = do
+
+  eiResponseBody <- runIO $ try $ do
+    req <- parseUrlThrow url
+    getResponseBody <$> httpBS req
+
+  case eiResponseBody :: Either SomeException ByteString of
+    Left _ -> embedFileUtf8 filePath
+    Right responseBody -> do
+      runIO $ BS.writeFile filePath responseBody
+      return . LitE . StringL . unpack $ LT.decodeUtf8 responseBody

--- a/src/Spago/Templates.hs
+++ b/src/Spago/Templates.hs
@@ -5,7 +5,7 @@ import qualified Data.ByteString.Internal as B
 import           Data.FileEmbed           (embedFile)
 import qualified Data.Text                as T
 
-import           Spago.TH                 (embedFileUtf8)
+import           Spago.TH                 (embedFileUtf8, embedURLWithFallback)
 
 
 packagesDhall :: T.Text
@@ -25,3 +25,15 @@ gitignore = $(embedFileUtf8 "templates/gitignore")
 
 bowerJson :: B.ByteString
 bowerJson = $(embedFile "templates/bower.json")
+
+docsSearchApp :: T.Text
+docsSearchApp =
+  $(embedURLWithFallback
+    "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.3/docs-search-app.js"
+    "templates/docs-search-app.js")
+
+docsSearch :: T.Text
+docsSearch =
+  $(embedURLWithFallback
+     "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.3/main.js"
+     "templates/purescript-docs-search")

--- a/src/Spago/Templates.hs
+++ b/src/Spago/Templates.hs
@@ -29,11 +29,11 @@ bowerJson = $(embedFile "templates/bower.json")
 docsSearchApp :: T.Text
 docsSearchApp =
   $(embedURLWithFallback
-    "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.3/docs-search-app.js"
+    "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.4/docs-search-app.js"
     "templates/docs-search-app.js")
 
 docsSearch :: T.Text
 docsSearch =
   $(embedURLWithFallback
-     "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.3/main.js"
+     "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.4/purescript-docs-search"
      "templates/purescript-docs-search")


### PR DESCRIPTION
The binary size is now 48MB.

Some more features to consider:

- Add a CLI flag that disables docs patching when running `spago docs`.
- Add ability to skip compilation when running `spago search`.
- Pin JS files by hash

Fix #89