### PR TITLE
Rename 'package-set-upgrade' → 'upgrade-set'

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,14 +548,14 @@ If you decide so, you can read up on how to do it [here][package-sets-contributi
 The version of the package-set you depend on is fixed in the `packages.dhall` file
 (look for the `upstream` var).
 
-You can upgrade to the latest version of the package-set with the `package-set-upgrade`
+You can upgrade to the latest version of the package-set with the `upgrade-set`
 command, that will automatically find out the latest version, download it, and write
 the new url and hashes in the `packages.dhall` file for you.
 
 Running it would look something like this:
 
 ```bash
-$ spago package-set-upgrade
+$ spago upgrade-set
 Found the most recent tag for "purescript/package-sets": "psc-0.12.3-20190227"
 Package-set upgraded to latest tag "psc-0.12.3-20190227"
 Fetching the new one and generating hashes.. (this might take some time)

--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -168,7 +168,7 @@ spagoUpdater token controlChan fetcherChan = go Nothing
                     , "git pull --rebase"
                     , "git checkout -B master origin/master"
                     , "cd templates"
-                    , "spago package-set-upgrade"
+                    , "spago upgrade-set"
                     , "cd .."
                     , "git checkout -B " <> Text.unpack branchName
                     , "git add templates/packages.dhall"

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -236,7 +236,7 @@ parser = do
       , listPackages
       , verify
       , verifySet
-      , packageSetUpgrade
+      , upgradeSet
       , freeze
       ]
 
@@ -270,8 +270,8 @@ parser = do
       , VerifySet <$> limitJobs <*> cacheFlag
       )
 
-    packageSetUpgrade =
-      ( "package-set-upgrade"
+    upgradeSet =
+      ( "upgrade-set"
       , "Upgrade the upstream in packages.dhall to the latest package-sets release"
       , pure PackageSetUpgrade
       )

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -133,7 +133,7 @@ packageSetVersionWarning = makeMessage
  [ "WARNING: the package-set version you're on doesn't check if the version of the"
  , "PureScript compiler installed on your system is compatible."
  , "If your build fails you might want to upgrade your set by running this command:"
- , "`spago package-set-upgrade`"
+ , "`spago upgrade-set`"
  , ""
  ]
 
@@ -146,7 +146,7 @@ pursVersionMismatch currentVersion minVersion = makeMessage
   , ""
   , "There are a few ways to solve this:"
   , "- install a compatible `purs` version (i.e. in the same 'semver range' as the one in the package set)"
-  , "- if the `purs` version is 'too new', you can try using `spago package-set-upgrade` to upgrade to the latest package set"
+  , "- if the `purs` version is 'too new', you can try using `spago upgrade-set` to upgrade to the latest package set"
   , "- if you know what you're doing and you want to void this check, you can override the `version` of the `metadata` package in the packages.dhall"
   , ""
   ]

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -98,7 +98,7 @@ makePackageSetFile force = do
 --   - if all of this succeeds, it will regenerate the hashes and write to file
 upgradePackageSet :: Spago m => m ()
 upgradePackageSet = do
-  echoDebug "Running `spago package-set-upgrade`"
+  echoDebug "Running `spago upgrade-set`"
   try getLatestRelease >>= \case
     Left (err :: SomeException) -> echoDebug $ Messages.failedToReachGitHub err
     Right releaseTagName -> do

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -201,7 +201,7 @@ spec = around_ setup $ do
       spago ["test"] >>= shouldBeSuccessOutput "test-output.txt"
 
 
-  describe "spago package-set-upgrade" $ do
+  describe "spago upgrade-set" $ do
 
     it "Spago should migrate package-sets from src/packages.dhall to the released one" $ do
 
@@ -213,7 +213,7 @@ spec = around_ setup $ do
             $ filter (not . null . Text.breakOnAll "https://github.com/purescript/package-sets")
             $ Text.lines packages
       writeTextFile "packages.dhall" "https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e"
-      spago ["package-set-upgrade"] >>= shouldBeSuccess
+      spago ["upgrade-set"] >>= shouldBeSuccess
       newPackages <- fmap Text.strip $ readTextFile "packages.dhall"
       newPackages `shouldBe` packageSetUrl
 


### PR DESCRIPTION
This renames the `package-set-upgrade` command to `upgrade-set`, to make it easier to type.
This is a breaking change