### PR TITLE
Refactor dry-run machinery so we print a clear list of dry actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ install:
 
 script:
   - |
+    set -e
     echo "Running tests"
     export PATH="${PATH}:$(pwd)/artifacts"
     if [ `uname` = "Darwin" ]

--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ ssh://git@foo.com/bar/baz.git
 ```
 
 
-#### My `install` command is failing with some errors about "too many open files"
+#### Spago is failing with some errors about "too many open files"
 
 This might happen because the limit of "open files per process" is too low in your OS - as
 `spago` will try to fetch all dependencies in parallel, and this requires lots of file operations.
@@ -962,7 +962,7 @@ This might happen because the limit of "open files per process" is too low in yo
 You can limit the number of concurrent operations with the `-j` flag, e.g.:
 
 ```
-$ spago install -j 10
+$ spago -j 10 install
 ```
 
 To get a ballpark value for the `j` flag you can take the result of the `ulimit -n` command

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -37,13 +37,13 @@ data Command
   = Init Bool
 
   -- | Install (download) dependencies defined in spago.dhall
-  | Install (Maybe Int) (Maybe CacheFlag) [PackageName]
+  | Install (Maybe CacheFlag) [PackageName]
 
   -- | Get source globs of dependencies in spago.dhall
   | Sources
 
   -- | Start a REPL.
-  | Repl (Maybe Int) (Maybe CacheFlag) [PackageName] [SourcePath] [ExtraArg] DepsOnly
+  | Repl (Maybe CacheFlag) [PackageName] [SourcePath] [ExtraArg] DepsOnly
 
   -- | Generate documentation for the project and its dependencies
   | Docs (Maybe Purs.DocsFormat) [SourcePath] DepsOnly
@@ -55,16 +55,16 @@ data Command
   | ListPackages (Maybe PackagesFilter) JsonFlag
 
   -- | Verify that a single package is consistent with the Package Set
-  | Verify (Maybe Int) (Maybe CacheFlag) PackageName
+  | Verify (Maybe CacheFlag) PackageName
 
     -- | Verify that the Package Set is correct
-  | VerifySet (Maybe Int) (Maybe CacheFlag)
+  | VerifySet (Maybe CacheFlag)
 
   -- | Test the project with some module, default Test.Main
   | Test (Maybe ModuleName) BuildOptions [ExtraArg]
 
   -- | Bump and tag a new version in preparation for release.
-  | BumpVersion (Maybe Int) DryRun VersionBump
+  | BumpVersion DryRun VersionBump
 
   -- | Run the project with some module, default Main
   | Run (Maybe ModuleName) BuildOptions [ExtraArg]
@@ -158,7 +158,7 @@ parser = do
     mainModule  = CLI.optional $ CLI.opt (Just . ModuleName) "main" 'm' "Module to be used as the application's entry point"
     toTarget    = CLI.optional $ CLI.opt (Just . TargetPath) "to" 't' "The target file path"
     docsFormat  = CLI.optional $ CLI.opt Purs.parseDocsFormat "format" 'f' "Docs output format (markdown | html | etags | ctags)"
-    limitJobs   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
+    jobsLimit   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     nodeArgs         = many $ CLI.opt (Just . ExtraArg) "node-args" 'a' "Argument to pass to node (run/test only)"
     replPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'd' "Package name to add to the REPL as dependency"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include"
@@ -167,8 +167,10 @@ parser = do
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     passthroughArgs = many $ CLI.arg (Just . ExtraArg) " ..any `purs compile` option" "Options passed through to `purs compile`; use -- to separate"
 
-    buildOptions  = BuildOptions <$> limitJobs <*> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
-    globalOptions = GlobalOptions <$> verbose <*> noFormat <*> usePsa
+    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
+
+    -- Note: by default we limit concurrency to 20
+    globalOptions = GlobalOptions <$> verbose <*> noFormat <*> usePsa <*> fmap (fromMaybe 20) jobsLimit
 
     projectCommands = CLI.subcommandGroup "Project commands:"
       [ initProject
@@ -196,7 +198,7 @@ parser = do
     repl =
       ( "repl"
       , "Start a REPL"
-      , Repl <$> limitJobs <*> cacheFlag <*> replPackageNames <*> sourcePaths <*> passthroughArgs <*> depsOnly
+      , Repl <$> cacheFlag <*> replPackageNames <*> sourcePaths <*> passthroughArgs <*> depsOnly
       )
 
     test =
@@ -243,7 +245,7 @@ parser = do
     install =
       ( "install"
       , "Install (download) all dependencies listed in spago.dhall"
-      , Install <$> limitJobs <*> cacheFlag <*> packageNames
+      , Install <$> cacheFlag <*> packageNames
       )
 
     sources =
@@ -261,13 +263,13 @@ parser = do
     verify =
       ( "verify"
       , "Verify that a single package is consistent with the Package Set"
-      , Verify <$> limitJobs <*> cacheFlag <*> packageName
+      , Verify <$> cacheFlag <*> packageName
       )
 
     verifySet =
       ( "verify-set"
       , "Verify that the whole Package Set builds correctly"
-      , VerifySet <$> limitJobs <*> cacheFlag
+      , VerifySet <$> cacheFlag
       )
 
     packageSetUpgrade =
@@ -290,7 +292,7 @@ parser = do
     bumpVersion =
       ( "bump-version"
       , "Bump and tag a new version, and generate bower.json, in preparation for release."
-      , BumpVersion <$> limitJobs <*> dryRun <*> versionBump
+      , BumpVersion <$> dryRun <*> versionBump
       )
 
 
@@ -355,19 +357,19 @@ main = do
   (flip runReaderT) globalOptions $
     case command of
       Init force                            -> Spago.Packages.initProject force
-      Install limitJobs cacheConfig packageNames
-        -> Spago.Packages.install limitJobs cacheConfig packageNames
+      Install cacheConfig packageNames      -> Spago.Packages.install cacheConfig packageNames
       ListPackages packagesFilter jsonFlag  -> Spago.Packages.listPackages packagesFilter jsonFlag
       Sources                               -> Spago.Packages.sources
-      Verify limitJobs cacheConfig package  -> Spago.Packages.verify limitJobs cacheConfig (Just package)
-      VerifySet limitJobs cacheConfig       -> Spago.Packages.verify limitJobs cacheConfig Nothing
+      Verify cacheConfig package            -> Spago.Packages.verify cacheConfig (Just package)
+      VerifySet cacheConfig                 -> Spago.Packages.verify cacheConfig Nothing
       PackageSetUpgrade                     -> Spago.Packages.upgradePackageSet
       Freeze                                -> Spago.Packages.freeze
       Build buildOptions                    -> Spago.Build.build buildOptions Nothing
       Test modName buildOptions nodeArgs    -> Spago.Build.test modName buildOptions nodeArgs
-      BumpVersion limitJobs dryRun spec     -> Version.bumpVersion limitJobs dryRun spec
+      BumpVersion dryRun spec               -> Version.bumpVersion dryRun spec
       Run modName buildOptions nodeArgs     -> Spago.Build.run modName buildOptions nodeArgs
-      Repl limitJobs cacheConfig replPackageNames paths pursArgs depsOnly -> Spago.Build.repl limitJobs cacheConfig replPackageNames paths pursArgs depsOnly
+      Repl cacheConfig replPackageNames paths pursArgs depsOnly
+        -> Spago.Build.repl cacheConfig replPackageNames paths pursArgs depsOnly
       BundleApp modName tPath shouldBuild buildOptions
         -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions
       BundleModule modName tPath shouldBuild buildOptions

--- a/src/Spago/Bower.hs
+++ b/src/Spago/Bower.hs
@@ -1,6 +1,6 @@
 module Spago.Bower
   ( bowerPath
-  , writeBowerJson
+  , generateBowerJson
   , runBowerInstall
   ) where
 
@@ -44,9 +44,9 @@ runBower args = do
   Turtle.procStrictWithErr cmd args empty
 
 
-writeBowerJson :: Spago m => m ()
-writeBowerJson = do
-  echo $ "Generating " <> bowerPath <> " using the package set versions.."
+generateBowerJson :: Spago m => m ByteString.ByteString
+generateBowerJson = do
+  echo $ "Generating a new Bower config using the package set versions.."
   config@Config{..} <- Config.ensureConfig
   PublishConfig{..} <- Config.ensurePublishConfig
 
@@ -67,8 +67,8 @@ writeBowerJson = do
   when ignored $ do
     die $ bowerPath <> " is being ignored by git - change this before continuing"
 
-  liftIO $ ByteString.writeFile bowerPath bowerJson
-  echo $ "Generated " <> bowerPath <> " using the package set"
+  echo $ "Generated a valid Bower config using the package set"
+  pure bowerJson
 
 
 runBowerInstall :: Spago m => m ()

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -44,8 +44,7 @@ data NoBuild = NoBuild | DoBuild
 data NoInstall = NoInstall | DoInstall
 
 data BuildOptions = BuildOptions
-  { maybeLimit      :: Maybe Int
-  , cacheConfig     :: Maybe GlobalCache.CacheFlag
+  { cacheConfig     :: Maybe GlobalCache.CacheFlag
   , shouldWatch     :: Watch
   , shouldClear     :: Watch.ClearScreen
   , sourcePaths     :: [Purs.SourcePath]
@@ -72,7 +71,7 @@ build BuildOptions{..} maybePostBuild = do
   config@Config.Config{ packageSet = PackageSet.PackageSet{..}, ..} <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
   case noInstall of
-    DoInstall -> Fetch.fetchPackages maybeLimit cacheConfig deps packagesMinPursVersion
+    DoInstall -> Fetch.fetchPackages cacheConfig deps packagesMinPursVersion
     NoInstall -> pure ()
   let allGlobs = Packages.getGlobs deps depsOnly configSourcePaths <> sourcePaths
       buildAction = do
@@ -88,14 +87,13 @@ build BuildOptions{..} maybePostBuild = do
 -- | Start a repl
 repl
   :: Spago m
-  => Maybe Int
-  -> Maybe GlobalCache.CacheFlag
+  => Maybe GlobalCache.CacheFlag
   -> [PackageSet.PackageName]
   -> [Purs.SourcePath]
   -> [Purs.ExtraArg]
   -> Packages.DepsOnly
   -> m ()
-repl maybeLimit cacheFlag newPackages sourcePaths passthroughArgs depsOnly = do
+repl cacheFlag newPackages sourcePaths passthroughArgs depsOnly = do
   echoDebug "Running `spago repl`"
 
   try Config.ensureConfig >>= \case
@@ -118,7 +116,7 @@ repl maybeLimit cacheFlag newPackages sourcePaths passthroughArgs depsOnly = do
         deps <- Packages.getProjectDeps updatedConfig
         let globs = Packages.getGlobs deps depsOnly $ Config.configSourcePaths updatedConfig
 
-        Fetch.fetchPackages maybeLimit cacheFlag deps packagesMinPursVersion
+        Fetch.fetchPackages cacheFlag deps packagesMinPursVersion
 
         Purs.repl globs passthroughArgs
 

--- a/src/Spago/DryRun.hs
+++ b/src/Spago/DryRun.hs
@@ -20,9 +20,9 @@ data DryAction m
 runDryActions :: Spago m => DryRun -> NonEmpty (DryAction m) -> m ()
 runDryActions DryRun dryActions = do
   echo "\nWARNING: this is a dry run, so these side effects were not performed:"
-  for_ dryActions $ \DryAction{..} -> echo $ "- " <> dryMessage
+  for_ dryActions $ \DryAction{..} -> echo $ "* " <> dryMessage
   echo "\nUse the `--no-dry-run` flag to run them"
 runDryActions NoDryRun dryActions = do
   for_ dryActions $ \DryAction{..} -> do
-    echo $ "Running action: " <> dryMessage
+    echo $ "** Running action: " <> dryMessage
     dryAction

--- a/src/Spago/DryRun.hs
+++ b/src/Spago/DryRun.hs
@@ -1,16 +1,28 @@
 module Spago.DryRun
   ( DryRun(..)
-  , showHelp
+  , DryAction(..)
+  , runDryActions
   ) where
 
 import Spago.Prelude
 
 
 -- | Whether to actually perform side-effects
-data DryRun = DryRun | NoDryRun deriving Eq
+data DryRun = DryRun | NoDryRun
 
+-- | Wrapper for Spago actions that can be dry run
+data DryAction m
+  = DryAction
+    { dryMessage :: Text
+    , dryAction  :: m ()
+    }
 
-showHelp :: Spago m => DryRun -> m ()
-showHelp dryRun = do
-  when (dryRun == DryRun) $ do
-    echo "This is a dry run. Side effects will not be performed. Pass --no-dry-run to change this."
+runDryActions :: Spago m => DryRun -> NonEmpty (DryAction m) -> m ()
+runDryActions DryRun dryActions = do
+  echo "\nWARNING: this is a dry run, so these side effects were not performed:"
+  for_ dryActions $ \DryAction{..} -> echo $ "- " <> dryMessage
+  echo "\nUse the `--no-dry-run` flag to run them"
+runDryActions NoDryRun dryActions = do
+  for_ dryActions $ \DryAction{..} -> do
+    echo $ "Running action: " <> dryMessage
+    dryAction

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -173,8 +173,8 @@ getReverseDeps packageSet@PackageSet{..} dep = do
 
 
 -- | Fetch all dependencies into `.spago/`
-install :: Spago m => Maybe Int -> Maybe CacheFlag -> [PackageName] -> m ()
-install maybeLimit cacheFlag newPackages = do
+install :: Spago m => Maybe CacheFlag -> [PackageName] -> m ()
+install cacheFlag newPackages = do
   echoDebug "Running `spago install`"
   config@Config{ packageSet = PackageSet{..}, ..} <- Config.ensureConfig
 
@@ -189,7 +189,7 @@ install maybeLimit cacheFlag newPackages = do
     []         -> pure ()
     additional -> Config.addDependencies config additional
 
-  Fetch.fetchPackages maybeLimit cacheFlag deps packagesMinPursVersion
+  Fetch.fetchPackages cacheFlag deps packagesMinPursVersion
 
 
 data PackagesFilter = TransitiveDeps | DirectDeps
@@ -275,8 +275,8 @@ sources = do
   pure ()
 
 
-verify :: Spago m => Maybe Int -> Maybe CacheFlag -> Maybe PackageName -> m ()
-verify maybeLimit cacheFlag maybePackage = do
+verify :: Spago m => Maybe CacheFlag -> Maybe PackageName -> m ()
+verify cacheFlag maybePackage = do
   echoDebug "Running `spago verify`"
   Config{ packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfig
   case maybePackage of
@@ -305,7 +305,7 @@ verify maybeLimit cacheFlag maybePackage = do
       deps <- getTransitiveDeps packageSet [name]
       let globs = getGlobs deps DepsOnly []
           quotedName = Messages.surroundQuote $ packageName name
-      Fetch.fetchPackages maybeLimit cacheFlag deps packagesMinPursVersion
+      Fetch.fetchPackages cacheFlag deps packagesMinPursVersion
       echo $ "Verifying package " <> quotedName
       Purs.compile globs []
       echo $ "Successfully verified " <> quotedName

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -132,6 +132,7 @@ data GlobalOptions = GlobalOptions
   { globalDebug    :: Bool
   , globalDoFormat :: DoFormat
   , globalUsePsa   :: UsePsa
+  , globalJobs     :: Int
   }
 
 type Spago m =

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -16,6 +16,7 @@ import qualified Safe.Foldable as Safe
 import qualified Spago.Bower   as Bower
 import           Spago.DryRun     (DryRun(..), DryAction(..), runDryActions)
 import qualified Spago.Git     as Git
+import Spago.Messages (surroundQuote)
 
 
 data VersionBump
@@ -96,5 +97,7 @@ bumpVersion dryRun spec = do
     die $ "A new " <> Bower.bowerPath <> " has been generated. Please commit this and run `bump-version` again."
 
   runDryActions dryRun
-    $ DryAction ("create new version tag " <> unparseVersion newVersion) (tagNewVersion oldVersion newVersion)
+    $ DryAction
+        ("create new git tag " <> surroundQuote (unparseVersion newVersion))
+        (tagNewVersion oldVersion newVersion)
     :| []

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -85,8 +85,6 @@ bumpVersion :: Spago m => DryRun -> VersionBump -> m ()
 bumpVersion dryRun spec = do
   Bower.writeBowerJson
 
-  Git.requireCleanWorkingTree
-
   oldVersion <- getCurrentVersion
   newVersion <- getNextVersion spec oldVersion
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,6 @@ extra-deps:
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85
 - Glob-0.10.0
 - turtle-1.5.14
-- github: jonathanlking/semver-range
-  commit: 185d12608b894fcceada2b2796d11798b2a8b2f8
+- semver-range-0.2.8
 nix:
   packages: [zlib]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -88,6 +88,13 @@ packages:
       sha256: 191eed87a5e8713a212ddfe4c5f4b819d07771c56becd92b8b5c6119f7ddad5d
   original:
     hackage: turtle-1.5.14
+- completed:
+    hackage: semver-range-0.2.8@sha256:44918080c220cf67b6e7c8ad16f01f3cfe1ac69d4f72e528e84d566348bb23c3,1941
+    pantry-tree:
+      size: 401
+      sha256: fd72964da8246cc09d477b4c6e6f20971de058917d08d9f8183f5c0e2116f9c6
+  original:
+    hackage: semver-range-0.2.8
 snapshots:
 - completed:
     size: 508406

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -67,8 +67,7 @@ spec = around_ setup $ do
 
     before_ (initGitTag "v1.2.3") $ it "Spago should not make a tag when not passing --no-dry-run" $ do
 
-      spago ["bump-version", "minor"] >>= shouldBeSuccessInfix
-        "Skipped creating new Git tag (v1.3.0) because this is a dry run."
+      spago ["bump-version", "minor"] >>= shouldBeSuccess
       getHighestTag >>= (`shouldBe` Just "v1.2.3")
 
     before_ (initGitTag "not-a-version") $ it "Spago should use v0.0.0 as initial version" $ do
@@ -98,7 +97,7 @@ spec = around_ setup $ do
 
     before_ initGit $ it "Spago should create bower.json, but not commit it" $ do
 
-      spago ["bump-version", "--no-dry-run", "minor"] >>= shouldBeFailureInfix
+      spago ["bump-version", "minor"] >>= shouldBeFailureInfix
          "A new bower.json has been generated. Please commit this and run `bump-version` again."
       mv "bower.json" "bump-version-bower.json"
       checkFixture "bump-version-bower.json"
@@ -108,7 +107,7 @@ spec = around_ setup $ do
       appendFile ".gitignore" "bower.json\n"
       commitAll
       spago ["bump-version", "minor"] >>= shouldBeFailureInfix
-        "bower.json is being ignored by git - change this before continuing."
+        "bower.json is being ignored by git - change this before continuing"
 
     before_ initGit $ it "Spago should generate URL#version for non-tagged dependency" $ do
 

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -97,7 +97,7 @@ spec = around_ setup $ do
 
     before_ initGit $ it "Spago should create bower.json, but not commit it" $ do
 
-      spago ["bump-version", "minor"] >>= shouldBeFailureInfix
+      spago ["bump-version", "--no-dry-run", "minor"] >>= shouldBeFailureInfix
          "A new bower.json has been generated. Please commit this and run `bump-version` again."
       mv "bower.json" "bump-version-bower.json"
       checkFixture "bump-version-bower.json"

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -75,7 +75,7 @@ spec = around_ setup $ do
 
       writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
       spago ["init"] >>= shouldBeSuccess
-      spago ["install", "-j10", "simple-json", "foreign"] >>= shouldBeSuccess
+      spago ["install", "-j 10", "simple-json", "foreign"] >>= shouldBeSuccess
       mv "spago.dhall" "spago-install-success.dhall"
       checkFixture "spago-install-success.dhall"
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -75,7 +75,7 @@ spec = around_ setup $ do
 
       writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
       spago ["init"] >>= shouldBeSuccess
-      spago ["install", "-j 10", "simple-json", "foreign"] >>= shouldBeSuccess
+      spago ["-j 10", "install", "simple-json", "foreign"] >>= shouldBeSuccess
       mv "spago.dhall" "spago-install-success.dhall"
       checkFixture "spago-install-success.dhall"
 


### PR DESCRIPTION
Also make the `--jobs` flag global instead of passing it around everywhere

New output:
```
$ spago bump-version minor
Generating bower.json using the package set versions..
Generated bower.json using the package set
No git version tags found, so assuming current version is v0.0.0
Running `bower install` so `pulp publish` can read resolved versions from it

WARNING: this is a dry run, so these side effects were not performed:
- create new git tag "v0.1.0"

Use the `--no-dry-run` flag to run them
```
