### PR TITLE
Stop reformatting the config file at every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,17 +324,6 @@ $ spago run --node-args "arg1 arg2"
 ```
 
 
-### Avoid re-formatting the `spago.dhall` and `packages.dhall` with each command
-
-You can pass the `--no-config-format` or `-F` global flag:
-
-``` bash
-$ spago build -F
-Installation complete.
-Build succeeded.
-```
-
-
 ### Test my project
 
 You can also test your project with `spago`:

--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -408,7 +408,7 @@ withAST path transform = do
       newExpr <- transformMExpr transform expr
       echo $ "Done. Updating the \"" <> path <> "\" file.."
       writeTextFile (pathFromText path) $ Dhall.prettyWithHeader header newExpr <> "\n"
-      liftIO $ Dhall.format DoFormat path
+      liftIO $ Dhall.format path
   where
     transformMExpr
       :: Monad m

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -151,7 +151,6 @@ parser = do
     depsOnly    = bool AllSources DepsOnly <$> CLI.switch "deps-only" 'd' "Only use sources from dependencies, skipping the project sources."
     clearScreen = bool NoClear DoClear <$> CLI.switch "clear-screen" 'l' "Clear the screen on rebuild (watch mode only)"
     noBuild     = bool DoBuild NoBuild <$> CLI.switch "no-build" 's' "Skip build step"
-    noFormat    = bool DoFormat NoFormat <$> CLI.switch "no-config-format" 'F' "Disable formatting the configuration file `spago.dhall`"
     jsonFlag    = bool JsonOutputNo JsonOutputYes <$> CLI.switch "json" 'j' "Produce JSON output"
     dryRun      = bool DryRun NoDryRun <$> CLI.switch "no-dry-run" 'f' "Actually perform side-effects (the default is to describe what would be done)"
     usePsa      = bool UsePsa NoPsa <$> CLI.switch "no-psa" 'P' "Don't build with `psa`, but use `purs`"
@@ -171,7 +170,7 @@ parser = do
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
 
     -- Note: by default we limit concurrency to 20
-    globalOptions = GlobalOptions <$> verbose <*> noFormat <*> usePsa <*> fmap (fromMaybe 20) jobsLimit
+    globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit
 
     projectCommands = CLI.subcommandGroup "Project commands:"
       [ initProject

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -9,7 +9,6 @@ module Spago.Prelude
   , pathFromText
   , assertDirectory
   , GlobalOptions (..)
-  , DoFormat (..)
   , UsePsa(..)
   , Spago
   , module X
@@ -18,6 +17,7 @@ module Spago.Prelude
   , Text
   , NonEmpty (..)
   , Seq (..)
+  , IsString
   , Map
   , Generic
   , Alternative
@@ -95,6 +95,7 @@ import           Data.List.NonEmpty            (NonEmpty (..))
 import           Data.Map                      (Map)
 import           Data.Maybe                    as X
 import           Data.Sequence                 (Seq (..))
+import           Data.String                   (IsString)
 import           Data.Text                     (Text)
 import           Data.Text.Prettyprint.Doc     (Pretty)
 import           Data.Traversable              (for)
@@ -126,15 +127,11 @@ instance Show SpagoError where
   show (SpagoError err) = Text.unpack err
 
 
--- | Flag to skip automatic formatting of the Dhall files
-data DoFormat = DoFormat | NoFormat deriving (Eq)
-
 -- | Flag to disable the automatic use of `psa`
 data UsePsa = UsePsa | NoPsa
 
 data GlobalOptions = GlobalOptions
   { globalDebug    :: Bool
-  , globalDoFormat :: DoFormat
   , globalUsePsa   :: UsePsa
   , globalJobs     :: Int
   }

--- a/src/Spago/PscPackage.hs
+++ b/src/Spago/PscPackage.hs
@@ -84,7 +84,7 @@ insDhall = do
 
   PackageSet.ensureFrozen
 
-  try (dhallToJSON PackageSet.pathText packagesJsonPath) >>= \case
+  try (dhallToJSON PackageSet.path packagesJsonPath) >>= \case
     Right _ -> do
       echo $ "Wrote packages.json to " <> packagesJsonText
       echo "Now you can run `psc-package install`."

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -3,11 +3,9 @@ module BumpVersionSpec (spec) where
 import           Prelude        hiding (FilePath)
 import qualified System.IO.Temp as Temp
 import           Test.Hspec     (Spec, around_, before_, describe, it, shouldBe)
-import           Turtle         (Text, cp, decodeString, mkdir, mv,
-                                 writeTextFile)
-import           Utils          (checkFileHasInfix, checkFixture, getHighestTag,
-                                 git, shouldBeFailure, shouldBeFailureInfix,
-                                 shouldBeSuccess, shouldBeSuccessInfix, spago,
+import           Turtle         (Text, cp, decodeString, mkdir, mv, writeTextFile)
+import           Utils          (checkFileHasInfix, checkFixture, getHighestTag, git,
+                                 shouldBeFailure, shouldBeFailureInfix, shouldBeSuccess, spago,
                                  withCwd)
 
 

--- a/test/PscPackageSpec.hs
+++ b/test/PscPackageSpec.hs
@@ -2,10 +2,8 @@ module PscPackageSpec (spec) where
 
 import           Control.Monad.Extra (whenM)
 import           Prelude             hiding (FilePath)
-import           Test.Hspec          (Spec, afterAll_, around_, beforeAll,
-                                      describe, it, shouldBe)
-import           Turtle              (FilePath, empty, procStrictWithErr, procs,
-                                      rm, testdir, testfile)
+import           Test.Hspec          (Spec, afterAll_, around_, beforeAll, describe, it, shouldBe)
+import           Turtle              (FilePath, empty, procs, rm, testdir, testfile)
 import           Utils               (shouldBeSuccess, spago, withCwd)
 
 testDir :: FilePath

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -1,13 +1,12 @@
 module SpagoSpec (spec) where
 
 import           Control.Concurrent (threadDelay)
-import           Data.Foldable      (for_)
 import qualified Data.Text          as Text
 import           Prelude            hiding (FilePath)
 import qualified System.IO.Temp     as Temp
 import           Test.Hspec         (Spec, around_, describe, it, shouldBe)
-import           Turtle             (ExitCode (..), cd, cp, decodeString, fromText, mkdir, mktree,
-                                     mv, readTextFile, rm, testdir, writeTextFile, shell, empty)
+import           Turtle             (ExitCode (..), cd, cp, decodeString, empty, mkdir, mktree, mv,
+                                     readTextFile, rm, shell, testdir, writeTextFile)
 import           Utils              (checkFixture, readFixture, runFor, shouldBeFailure,
                                      shouldBeFailureOutput, shouldBeSuccess, shouldBeSuccessOutput,
                                      spago, withCwd)

--- a/test/fixtures/run-no-psa.txt
+++ b/test/fixtures/run-no-psa.txt
@@ -1,6 +1,7 @@
 🍝
 Running NodeJS
 Running `spago build`
+Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
 Getting transitive deps
 Running `fetchPackages`

--- a/test/fixtures/run-output-psa-not-installed.txt
+++ b/test/fixtures/run-output-psa-not-installed.txt
@@ -1,6 +1,7 @@
 🍝
 Running NodeJS
 Running `spago build`
+Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
 Getting transitive deps
 Running `fetchPackages`

--- a/test/fixtures/run-output.txt
+++ b/test/fixtures/run-output.txt
@@ -1,6 +1,7 @@
 🍝
 Running NodeJS
 Running `spago build`
+Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
 Getting transitive deps
 Running `fetchPackages`


### PR DESCRIPTION
Fix #300 

This implements the fix described in https://github.com/spacchetti/spago/issues/300#issuecomment-515676453: we remove the `--no-config-format` flag and Spago will not reformat the config file unless it's needed, removing the need for the flag

cc @joneshf @liamgoodacre @aniketd: since there is some noise in the PR, the actual fix for this is basically [these lines](https://github.com/spacchetti/spago/pull/339/files#diff-47b561d66d3fdc8da263081ea4048920R250-R253)