### PR TITLE
Add flag for specifying config path location

### DIFF
--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -407,7 +407,7 @@ withAST path transform = do
     Just (header, expr) -> do
       newExpr <- transformMExpr transform expr
       echo $ "Done. Updating the \"" <> path <> "\" file.."
-      writeTextFile (pathFromText path) $ Dhall.prettyWithHeader header newExpr <> "\n"
+      writeTextFile path $ Dhall.prettyWithHeader header newExpr <> "\n"
       liftIO $ Dhall.format path
   where
     transformMExpr

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -10,20 +10,19 @@ import qualified Paths_spago         as Pcli
 import qualified System.Environment  as Env
 import qualified Turtle              as CLI
 
-import           Spago.Build         (BuildOptions (..), ExtraArg (..),
-                                      ModuleName (..), SourcePath (..),
-                                      TargetPath (..), Watch (..),
-                                      WithMain (..), NoBuild (..),
-                                      NoInstall (..), DepsOnly (..))
+import           Spago.Build         (BuildOptions (..), DepsOnly (..), ExtraArg (..),
+                                      ModuleName (..), NoBuild (..), NoInstall (..),
+                                      SourcePath (..), TargetPath (..), Watch (..), WithMain (..))
 import qualified Spago.Build
+import qualified Spago.Config        as Config
 import           Spago.DryRun        (DryRun (..))
 import           Spago.GlobalCache   (CacheFlag (..))
 import           Spago.Messages      as Messages
-import           Spago.Packages      (PackageName (..), PackagesFilter (..), JsonFlag(..))
+import           Spago.Packages      (JsonFlag (..), PackageName (..), PackagesFilter (..))
 import qualified Spago.Packages
 import qualified Spago.PscPackage    as PscPackage
 import qualified Spago.Purs          as Purs
-import           Spago.Version       (VersionBump(..))
+import           Spago.Version       (VersionBump (..))
 import qualified Spago.Version       as Version
 import           Spago.Watch         (ClearScreen (..))
 
@@ -171,7 +170,7 @@ parser = do
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
 
     -- Note: by default we limit concurrency to 20
-    globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit <*> configPath
+    globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit <*> fmap (fromMaybe Config.defaultPath) configPath
 
     projectCommands = CLI.subcommandGroup "Project commands:"
       [ initProject

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -154,6 +154,7 @@ parser = do
     jsonFlag    = bool JsonOutputNo JsonOutputYes <$> CLI.switch "json" 'j' "Produce JSON output"
     dryRun      = bool DryRun NoDryRun <$> CLI.switch "no-dry-run" 'f' "Actually perform side-effects (the default is to describe what would be done)"
     usePsa      = bool UsePsa NoPsa <$> CLI.switch "no-psa" 'P' "Don't build with `psa`, but use `purs`"
+    configPath  = CLI.optional $ CLI.optText "config" 'x' "Optional config path to be used instead of the default spago.dhall"
 
     mainModule  = CLI.optional $ CLI.opt (Just . ModuleName) "main" 'm' "Module to be used as the application's entry point"
     toTarget    = CLI.optional $ CLI.opt (Just . TargetPath) "to" 't' "The target file path"
@@ -170,7 +171,7 @@ parser = do
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
 
     -- Note: by default we limit concurrency to 20
-    globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit
+    globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit <*> configPath
 
     projectCommands = CLI.subcommandGroup "Project commands:"
       [ initProject

--- a/src/Spago/Dhall.hs
+++ b/src/Spago/Dhall.hs
@@ -48,7 +48,7 @@ prettyWithHeader header expr = do
 
 readRawExpr :: Text -> IO (Maybe (Text, DhallExpr Dhall.Import))
 readRawExpr pathText = do
-  exists <- testfile $ pathFromText pathText
+  exists <- testfile pathText
   if exists
     then (do
       packageSetText <- readTextFile $ pathFromText pathText
@@ -62,7 +62,7 @@ writeRawExpr pathText (header, expr) = do
   -- if it doesn't we don't write to file.
   resolvedExpr <- Dhall.Import.load expr
   throws (Dhall.TypeCheck.typeOf resolvedExpr)
-  writeTextFile (pathFromText pathText) $ prettyWithHeader header expr <> "\n"
+  writeTextFile pathText $ prettyWithHeader header expr <> "\n"
   format pathText
 
 
@@ -76,7 +76,7 @@ fromTextLit
   :: (Pretty a, Typeable a)
   => DhallExpr a
   -> Either (ReadError a) Text
-fromTextLit (Dhall.TextLit (Dhall.Chunks [] str)) = Right str
+fromTextLit(Dhall.TextLit (Dhall.Chunks [] str)) = Right str
 fromTextLit expr                                  = Left $ ExprIsNotTextLit expr
 
 

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -129,7 +129,7 @@ getMetadata cacheFlag = do
 
       -- Check if the metadata is in global cache and fresher than 1 day
       shouldDownloadMeta <- tryIO (liftIO $ do
-          fileExists <- testfile $ Turtle.decodeString globalPathToMeta
+          fileExists <- testfile $ Text.pack globalPathToMeta
           lastModified <- getModificationTime globalPathToMeta
           now <- Time.getCurrentTime
           -- Note: `NomiNalDiffTime` is 1 second

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -56,7 +56,7 @@ upgradePackageSet = do
   globalCacheDir <- GlobalCache.getGlobalCacheDir
   assertDirectory globalCacheDir
   let globalPathToCachedTag = globalCacheDir </> "package-sets-tag.txt"
-  let writeTagCache releaseTagName = writeTextFile (pathFromText $ Text.pack globalPathToCachedTag) releaseTagName
+  let writeTagCache releaseTagName = writeTextFile (Text.pack globalPathToCachedTag) releaseTagName
   let readTagCache = try $ readTextFile $ pathFromText $ Text.pack globalPathToCachedTag
   let downloadTagToCache =
         try (Retry.recoverAll (Retry.fullJitterBackoff 50000 <> Retry.limitRetries 5) $ \_ -> getLatestRelease1 <|> getLatestRelease2) >>= \case

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -78,10 +78,9 @@ initProject force = do
           action
 
     copyIfNotExists dest srcTemplate = do
-      let destPath = pathFromText dest
-      (testfile destPath) >>= \case
+      (testfile dest) >>= \case
         True  -> echo $ Messages.foundExistingFile dest
-        False -> writeTextFile destPath srcTemplate
+        False -> writeTextFile dest srcTemplate
 
 
 -- | Only build deps and ignore input paths

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -7,6 +7,7 @@ module Spago.Prelude
   , Dhall.Core.throws
   , hush
   , pathFromText
+  , testfile'
   , assertDirectory
   , GlobalOptions (..)
   , UsePsa(..)
@@ -134,9 +135,10 @@ instance Show SpagoError where
 data UsePsa = UsePsa | NoPsa
 
 data GlobalOptions = GlobalOptions
-  { globalDebug  :: Bool
-  , globalUsePsa :: UsePsa
-  , globalJobs   :: Int
+  { globalDebug      :: Bool
+  , globalUsePsa     :: UsePsa
+  , globalJobs       :: Int
+  , globalConfigPath :: Maybe Text
   }
 
 type Spago m =
@@ -171,10 +173,11 @@ die reason = throwM $ SpagoError reason
 hush :: Either a b -> Maybe b
 hush = either (const Nothing) Just
 
-
 pathFromText :: Text -> Turtle.FilePath
 pathFromText = Turtle.fromText
 
+testfile' :: MonadIO m => Text -> m Bool
+testfile' = testfile . pathFromText
 
 readTextFile :: MonadIO m => Turtle.FilePath -> m Text
 readTextFile = liftIO . Turtle.readTextFile

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -138,7 +138,7 @@ data GlobalOptions = GlobalOptions
   { globalDebug      :: Bool
   , globalUsePsa     :: UsePsa
   , globalJobs       :: Int
-  , globalConfigPath :: Maybe Text
+  , globalConfigPath :: IsString t => t
   }
 
 type Spago m =

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -7,7 +7,6 @@ module Spago.Prelude
   , Dhall.Core.throws
   , hush
   , pathFromText
-  , testfile'
   , assertDirectory
   , GlobalOptions (..)
   , UsePsa(..)
@@ -113,8 +112,7 @@ import           System.FilePath               (isAbsolute, pathSeparator, (</>)
 import           System.IO                     (hPutStrLn)
 import           Turtle                        (ExitCode (..), FilePath, appendonly, chmod,
                                                 executable, mktree, repr, shell, shellStrict,
-                                                shellStrictWithErr, systemStrictWithErr, testdir,
-                                                testfile)
+                                                shellStrictWithErr, systemStrictWithErr, testdir)
 import           UnliftIO                      (MonadUnliftIO, withRunInIO)
 import           UnliftIO.Directory            (getModificationTime, makeAbsolute)
 import           UnliftIO.Exception            (IOException, handleAny, try, tryIO)
@@ -138,7 +136,7 @@ data GlobalOptions = GlobalOptions
   { globalDebug      :: Bool
   , globalUsePsa     :: UsePsa
   , globalJobs       :: Int
-  , globalConfigPath :: IsString t => t
+  , globalConfigPath :: Text
   }
 
 type Spago m =
@@ -176,15 +174,15 @@ hush = either (const Nothing) Just
 pathFromText :: Text -> Turtle.FilePath
 pathFromText = Turtle.fromText
 
-testfile' :: MonadIO m => Text -> m Bool
-testfile' = testfile . pathFromText
+testfile :: MonadIO m => Text -> m Bool
+testfile = Turtle.testfile . pathFromText
 
 readTextFile :: MonadIO m => Turtle.FilePath -> m Text
 readTextFile = liftIO . Turtle.readTextFile
 
 
-writeTextFile :: MonadIO m => Turtle.FilePath -> Text -> m ()
-writeTextFile path text = liftIO $ Turtle.writeTextFile path text
+writeTextFile :: MonadIO m => Text -> Text -> m ()
+writeTextFile path text = liftIO $ Turtle.writeTextFile (Turtle.fromText path) text
 
 
 with :: MonadIO m => Turtle.Managed a -> (a -> IO r) -> m r

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -254,7 +254,7 @@ docsSearchVersion = "v0.0.4"
 -- | Check if the file is present and more recent than 1 day
 shouldRefreshFile :: Spago m => FilePath.FilePath -> m Bool
 shouldRefreshFile path = (tryIO $ liftIO $ do
-  fileExists <- testfile $ Turtle.decodeString path
+  fileExists <- testfile $ Text.pack path
   lastModified <- getModificationTime path
   now <- Time.getCurrentTime
   -- Note: `NomiNalDiffTime` is 1 second

--- a/src/Spago/PscPackage.hs
+++ b/src/Spago/PscPackage.hs
@@ -28,11 +28,8 @@ data PscPackage = PscPackage
 instance JSON.ToJSON PscPackage
 instance JSON.FromJSON PscPackage
 
-configPathText :: Text
-configPathText = "psc-package.json"
-
-configPath :: T.FilePath
-configPath = T.fromText configPathText
+configPath :: IsString t => t
+configPath = "psc-package.json"
 
 pscPackageBasePathText :: Text
 pscPackageBasePathText = ".psc-package/local/.set/"
@@ -55,7 +52,7 @@ encodePscPackage = LT.toStrict . LT.decodeUtf8 . encodePretty
 
 -- | Given a path to a Dhall file and an output path to a JSON file,
 --   reads the Dhall, converts it, and writes it as JSON
-dhallToJSON :: Spago m => T.Text -> T.FilePath -> m ()
+dhallToJSON :: Spago m => T.Text -> T.Text -> m ()
 dhallToJSON inputPath outputPath = do
   let config = JSON.Config
                { JSON.confIndent = JSON.Spaces 2
@@ -84,7 +81,7 @@ insDhall = do
 
   PackageSet.ensureFrozen
 
-  try (dhallToJSON PackageSet.path packagesJsonPath) >>= \case
+  try (dhallToJSON PackageSet.path packagesJsonText) >>= \case
     Right _ -> do
       echo $ "Wrote packages.json to " <> packagesJsonText
       echo "Now you can run `psc-package install`."

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -128,6 +128,21 @@ spec = around_ setup $ do
       writeTextFile "packages.dhall" "let pkgs = ./packagesBase.dhall in pkgs // { spago = { dependencies = [\"prelude\"], repo = \"https://github.com/spacchetti/spago.git\", version = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" }}"
       spago ["install", "spago"] >>= shouldBeFailure
 
+    it "Spago should be able to update dependencies in an alternative config" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      writeTextFile "alternative1.dhall" "./spago.dhall // {dependencies = [\"prelude\"]}"
+      spago ["-x", "alternative1.dhall", "install", "simple-json"] >>= shouldBeSuccess
+      checkFixture "alternative1.dhall"
+
+    it "Spago should not change the alternative config if it does not change dependencies" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      writeTextFile "alternative2.dhall" "./spago.dhall // { sources = [ \"src/**/*.purs\" ] }"
+      spago ["-x", "alternative2.dhall", "install", "simple-json"] >>= shouldBeSuccess
+      spago ["-x", "alternative2.dhall", "install", "simple-json"] >>= shouldBeSuccessOutput "alternative2install.txt"
+      checkFixture "alternative2.dhall"
+
     it "Spago should install successfully when there are local dependencies sharing the same packages.dhall" $ do
 
       -- Create local 'lib-a' package that depends on lib-c

--- a/test/fixtures/alternative1.dhall
+++ b/test/fixtures/alternative1.dhall
@@ -1,0 +1,1 @@
+./spago.dhall // { dependencies = [ "prelude", "simple-json" ] }

--- a/test/fixtures/alternative2.dhall
+++ b/test/fixtures/alternative2.dhall
@@ -1,0 +1,1 @@
+./spago.dhall // { sources = [ "src/**/*.purs" ] }

--- a/test/fixtures/alternative2install.txt
+++ b/test/fixtures/alternative2install.txt
@@ -1,0 +1,2 @@
+WARNING: configuration file was not updated. You should have a record with the `dependencies` key for this to work.
+Installation complete.


### PR DESCRIPTION
### Description of the change

fixes #329, specify config path globally if desired for specific usages

e.g.

`spago.dhall`

```dhall
-- ...
, sources =
    [ "codegen/**/*.purs", "src/**/*.purs", "test/**/*.purs" ]
}
```

i don't want to build with all the sources.

`codegen.dhall`

```dhall
./spago.dhall // {
  sources = [
	"src/**/*.purs"
  ]
}
```

```
$ spago -x codegen.dhall build
# works fine
```

other uses:

"optional app separate from library"

"test config overrides and modifications"

"some other config modifications"

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
