### PR TITLE
Add an explicit purs args flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Breaking changes (!!!):
+- **Flags and arguments that you want to give to `purs` are now passed with `--purs-args`**
+
+  The previous behaviour in which all arguments that could not parse as `spago` arguments
+  were passed along to `purs` was sometimes confusing (e.g. when using `--path` and multiple
+  arguments).
 
 ## [0.9.0] - 2019-07-30
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ $ spago build --path 'another_source/**/*.purs'
 E.g. if you wish to output your files in some other place than `output/`, you can run
 
 ```bash
-$ spago build -- -o myOutput/
+$ spago build --purs-args '-o myOutput/'
 ```
 
 If you wish to automatically have your project rebuilt when making changes to source files
@@ -315,7 +315,7 @@ $ spago run
 $ spago run --main ModulePath.To.Main
 
 # And pass arguments through to `purs compile`
-$ spago run --main ModulePath.To.Main -- --verbose-errors
+$ spago run --main ModulePath.To.Main --purs-args '--verbose-errors'
 
 # Or pass arguments to node
 $ spago run --node-args "arg1 arg2"

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -165,9 +165,9 @@ parser = do
 
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
-    passthroughArgs = many $ CLI.arg (Just . ExtraArg) " ..any `purs compile` option" "Options passed through to `purs compile`; use -- to separate"
+    pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
 
-    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> passthroughArgs <*> depsOnly
+    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly
 
     -- Note: by default we limit concurrency to 20
     globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit
@@ -199,7 +199,7 @@ parser = do
     repl =
       ( "repl"
       , "Start a REPL"
-      , Repl <$> cacheFlag <*> replPackageNames <*> sourcePaths <*> passthroughArgs <*> depsOnly
+      , Repl <$> cacheFlag <*> replPackageNames <*> sourcePaths <*> pursArgs <*> depsOnly
       )
 
     test =

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -51,7 +51,7 @@ data BuildOptions = BuildOptions
   , shouldClear     :: Watch.ClearScreen
   , sourcePaths     :: [Purs.SourcePath]
   , noInstall       :: NoInstall
-  , passthroughArgs :: [Purs.ExtraArg]
+  , pursArgs        :: [Purs.ExtraArg]
   , depsOnly        :: Packages.DepsOnly
   }
 
@@ -77,7 +77,7 @@ build BuildOptions{..} maybePostBuild = do
     NoInstall -> pure ()
   let allGlobs = Packages.getGlobs deps depsOnly configSourcePaths <> sourcePaths
       buildAction = do
-        Purs.compile allGlobs passthroughArgs
+        Purs.compile allGlobs pursArgs
         case maybePostBuild of
           Just action -> action
           Nothing     -> pure ()
@@ -95,14 +95,14 @@ repl
   -> [Purs.ExtraArg]
   -> Packages.DepsOnly
   -> m ()
-repl cacheFlag newPackages sourcePaths passthroughArgs depsOnly = do
+repl cacheFlag newPackages sourcePaths pursArgs depsOnly = do
   echoDebug "Running `spago repl`"
 
   try Config.ensureConfig >>= \case
     Right config@Config.Config{..} -> do
       deps <- Packages.getProjectDeps config
       let globs = Packages.getGlobs deps depsOnly configSourcePaths <> sourcePaths
-      Purs.repl globs passthroughArgs
+      Purs.repl globs pursArgs
     Left (err :: SomeException) -> do
       echoDebug $ tshow err
       cacheDir <- GlobalCache.getGlobalCacheDir
@@ -120,7 +120,7 @@ repl cacheFlag newPackages sourcePaths passthroughArgs depsOnly = do
 
         Fetch.fetchPackages cacheFlag deps packagesMinPursVersion
 
-        Purs.repl globs passthroughArgs
+        Purs.repl globs pursArgs
 
 -- | Test the project: compile and run "Test.Main"
 --   (or the provided module name) with node

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -181,7 +181,13 @@ spec = around_ setup $ do
     it "Spago should pass options to purs" $ do
 
       spago ["init"] >>= shouldBeSuccess
-      spago ["build", "--", "-o", "myOutput"] >>= shouldBeSuccess
+      spago ["build", "--purs-args", "-o myOutput"] >>= shouldBeSuccess
+      testdir "myOutput" >>= (`shouldBe` True)
+
+    it "Spago should pass multiple options to purs" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      spago ["build", "--purs-args", "-o", "--purs-args", "myOutput"] >>= shouldBeSuccess
       testdir "myOutput" >>= (`shouldBe` True)
 
     it "Spago should build successfully with sources included from custom path" $ do


### PR DESCRIPTION
### Description of the change

Add an explicit flag for arguments passed over to `purs` as per #353. Fixes #353 

I am not sure about the short flag name, but everything that immediately comes to mind is already taken.
### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)