### PR TITLE
Fix syntax error in template comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- fix Dhall syntax error in packages.dhall template
+
 ## [0.9.0] - 2019-07-30
 
 Breaking changes (!!!):

--- a/templates/packages.dhall
+++ b/templates/packages.dhall
@@ -107,7 +107,7 @@ let additions =
           , "node-readline"
           , "datetime"
           , "now"
-          ],
+          ]
       , repo =
           "https://github.com/hdgarrood/purescript-benchotron.git"
       , version =


### PR DESCRIPTION
### Description of the change

The code example in packages.dhall template has syntax error (duplicated comma), so it can't be just copy-pasted.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
