### PR TITLE
Use `git clone` instead of `git fetch` when fetching a package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Bugfixes:
 - Do not compile files twice when using `--watch` and Vim (#346)
 - fix Dhall syntax error in packages.dhall template
+- Use `git clone` instead of `git fetch` when fetching a package (#373)
 
 ## [0.9.0] - 2019-07-30
 

--- a/src/Spago/FetchPackage.hs
+++ b/src/Spago/FetchPackage.hs
@@ -163,9 +163,7 @@ fetchPackage metadata pair@(packageName'@PackageName{..}, Package{ location = Re
     quotedName = surroundQuote packageName
 
     git = Text.intercalate " && "
-           [ "git init"
-           , "git remote add origin " <> unRepo repo
-           , "git fetch origin"
+           [ "git clone " <> unRepo repo <> " ."
            , "git -c advice.detachedHead=false checkout " <> version
            ]
 


### PR DESCRIPTION
fix #373 