### PR TITLE
Simplify getGlobalCacheDir, change Windows default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bugfixes:
 - Do not compile files twice when using `--watch` and Vim (#346)
 - fix Dhall syntax error in packages.dhall template
 - Use `git clone` instead of `git fetch` when fetching a package (#373)
+- Fixes Windows global cache location; now uses `LocalAppData` as default (#384, #380)
 
 ## [0.9.0] - 2019-07-30
 

--- a/package.yaml
+++ b/package.yaml
@@ -67,7 +67,7 @@ library:
   - fsnotify
   - Glob
   - stm
-  - directory
+  - directory >= 1.3.4.0
   - mtl
   - exceptions
   - unliftio

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -68,16 +68,6 @@ cannotFindPackagesButItsFine = makeMessage
   [ "WARNING: did not find a " <> surroundQuote "packages.dhall" <> " in your current location, skipping compiler version check"
   ]
 
-cannotGetGlobalCacheDir :: Text
-cannotGetGlobalCacheDir = makeMessage
-  [ "ERROR: Spago was not able to get a directory for the global cache. To fix this there are some things you could do:"
-  , ""
-  , "- Set either the `HOME` or `XDG_CACHE_HOME` environment variable. Depending on your OS you'll have to type a different thing in your terminal to do it:"
-  , "  On Windows:    set XDG_CACHE_DIR=\"C:\\tmp\\spago\""
-  , "  On Linux/Mac:  export XDG_CACHE_HOME='/tmp/spago'"
-  , ""
-  , "- Disable the global cache entirely, by passing to Spago `--global-cache skip`"
-  ]
 
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,5 +20,6 @@ extra-deps:
 - th-lift-0.8.0.1@sha256:cceb81b12c0580e02a7a3898b6d60cca5e1be080741f69ddde4f12210d8ba7ca,1960
 - th-lift-instances-0.1.13@sha256:2852e468511805cb25d9e3923c9e91647d008ab4a764ec0921e5e40ff8a8e874,2625
 - semver-range-0.2.8
+- directory-1.3.4.0@sha256:500019f04494324d1df16cf83eefeb3f809b2b20b32a32ccd755ee0439c18bfd
 nix:
   packages: [zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,5 +21,6 @@ extra-deps:
 - th-lift-instances-0.1.13@sha256:2852e468511805cb25d9e3923c9e91647d008ab4a764ec0921e5e40ff8a8e874,2625
 - semver-range-0.2.8
 - directory-1.3.4.0@sha256:500019f04494324d1df16cf83eefeb3f809b2b20b32a32ccd755ee0439c18bfd
+- process-1.6.5.1@sha256:77a9afeb676357f67fe5cf1ad79aca0745fb6f7fb96b786d510af08f622643f6,2468
 nix:
   packages: [zlib]


### PR DESCRIPTION
Simplifies greatly the getGlobalCacheDir function by using `Directory.getXdgDirectory`, which does most of the work for us.

On Linux/MacOS, behavior isn't changed: will search for `$XDG_CACHE_HOME`, then `$HOME`, and will error if neither are found.*

On Windows, the default (if no `xdg_cache_home` exists) is changed to `%LOCALAPPDATA%`. This is really the "correct" place for it on Windows (rather than `~/.cache`) to be a good citizen.

It no longer checks for/uses `$HOME` on Windows, but I'd argue that isn't necessary: if you want it the *nixy way, you can just set `$xdg_cache_home` instead (as I do). Should also fix #380. 

----
*Now something I didn't quite understand was the alternative3 case in the original code.

https://github.com/spacchetti/spago/blob/13cf90cddb1e3e2b7338169d98799b6bc6a54ffe/src/Spago/GlobalCache.hs#L149-L178

At the end of the first line you have `alternative₃ <|> err`, but alternative3 can't fail, so the error message will never be shown?

So I don't know which outcome is intended if neither `$xdg_cache_home` nor `$home` are found: use a `.spago-global-cache` folder (in the project folder?), or show an error message; so I just went with the error message for now, which I've also modified, since it no longer applies to Windows.

Will have to see if this works on the CI...

----



### Checklist:
(Will do after review)
- [x] Added the change to the "Unreleased" section of the changelog

