### PR TITLE
Fix watch paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bugfixes:
 - Use `git clone` instead of `git fetch` when fetching a package (#373)
 - Fixes Windows global cache location; now uses `LocalAppData` as default (#384, #380)
 - Fix failure to copy to global cache on a different filesystem (#385)
+- Fix watch function on Windows (issue with paths) (#387, #380)
 
 ## [0.9.0] - 2019-07-30
 

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -9,10 +9,10 @@ import           Spago.Prelude          hiding (FilePath)
 import           Control.Concurrent.STM (check)
 import qualified Data.Map.Strict        as Map
 import qualified Data.Set               as Set
-import qualified Data.Text              as Text
 import           GHC.IO                 (FilePath)
 import           GHC.IO.Exception
 import           System.Console.ANSI    (clearScreen)
+import           System.FilePath        (splitDirectories)
 import qualified System.FilePath.Glob   as Glob
 import qualified System.FSNotify        as Watch
 import           System.IO              (getLine)
@@ -175,15 +175,9 @@ fileWatchConf watchConfig shouldClear inner = withManagerConf watchConfig $ \man
 
 
 globToParent :: Glob.Pattern -> FilePath
-globToParent glob = go base $ map Text.unpack pathComponents
+globToParent glob = go pathHead pathRest
   where
-    path = Glob.decompile glob
-
-    base = case isAbsolute path of
-      True  -> [pathSeparator]
-      False -> "."
-
-    pathComponents = Text.split (== pathSeparator) $ Text.pack path
+    pathHead : pathRest = splitDirectories $ Glob.decompile glob
 
     go acc []           = acc
     go acc ("*":_rest)  = acc


### PR DESCRIPTION
Fixes invalid path issue described in https://github.com/spacchetti/spago/issues/380#issuecomment-524583489

[`Watch.globToParent`](https://github.com/spacchetti/spago/blob/ba97e38bd5377b8ca316b4dd3dfe598c70708681/src/Spago/Watch.hs#L177-L192) had some issues on Windows:
- Use of `(== pathSeparator)` can cause problems since there are 2 different path separators.
- Splitting and re-combining the glob paths resulted in paths missing a slash after the drive letter, ie: `C:Path\To\Folder`. These are treated as relative paths (on the given drive), eventually resulting in invalid paths.

This commit does bring a slight change in behavior in that relative paths no longer have "./" prepended to them, but I don't think that's a problem? (a relative path is still a relative path, with or without the "./").

There aren't currently any tests for watching (that's kinda difficult I think?)
