### PR TITLE
Support watching js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Bugfixes:
 - Fix watch function on Windows (issue with paths) (#387, #380)
 - "Quit" command in watch mode now actually quits (#390, #389)
 
+New features:
+- Support watching js files (#407, #205)
+
 ## [0.9.0] - 2019-07-30
 
 Breaking changes (!!!):

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -85,9 +85,14 @@ build BuildOptions{..} maybePostBuild = do
           Just action -> action
           Nothing     -> pure ()
   absoluteGlobs <- traverse makeAbsolute $ Text.unpack . Purs.unSourcePath <$> allGlobs
+  absoluteJSGlobs <- traverse makeAbsolute $ Text.unpack . Purs.unSourcePath
+    <$> (Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths)
+
   case shouldWatch of
     BuildOnce -> buildAction
-    Watch     -> Watch.watch (Set.fromAscList $ fmap Glob.compile absoluteGlobs) shouldClear buildAction
+    Watch     -> Watch.watch
+      (Set.fromAscList $ fmap Glob.compile $ absoluteGlobs <> absoluteJSGlobs)
+      shouldClear buildAction
 
 -- | Start a repl
 repl

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -5,6 +5,7 @@ module Spago.Packages
   , verify
   , listPackages
   , getGlobs
+  , getJsGlobs
   , getDirectDeps
   , getProjectDeps
   , PackageSet.upgradePackageSet
@@ -93,6 +94,17 @@ getGlobs deps depsOnly configSourcePaths
   <> case depsOnly of
     DepsOnly   -> []
     AllSources -> configSourcePaths
+
+
+getJsGlobs :: [(PackageName, Package)] -> DepsOnly -> [Purs.SourcePath] -> [Purs.SourcePath]
+getJsGlobs deps depsOnly configSourcePaths
+  = map (\pair
+          -> Purs.SourcePath $ Text.pack $ Fetch.getLocalCacheDir pair
+          <> "/src/**/*.js") deps
+  <> case depsOnly of
+    DepsOnly   -> []
+    AllSources -> Purs.SourcePath . Text.replace ".purs" ".js" . Purs.unSourcePath
+      <$> configSourcePaths
 
 
 -- | Return the direct dependencies of the current project


### PR DESCRIPTION
### Description of the change

Fixes #205. As discussed in https://github.com/spacchetti/spago/issues/205#issuecomment-493100821, added a `getJsGlobs` function.

- [x] Added the change to the "Unreleased" section of the changelog

