### PR TITLE
Warn (but don't error) when trying to watch missing directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ New features:
 - Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
 - Support building for alternate backends (#355). E.g: Use `backend = "psgo"` entry in `spago.dhall` to compile with `psgo`
 
+Bugfixes:
+- Warn (but don't error) when trying to watch missing directories (#406)
+
 ## [0.10.0] - 2019-09-21
 
 Breaking changes (!!!):

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -87,7 +87,19 @@ build BuildOptions{..} maybePostBuild = do
   absoluteGlobs <- traverse makeAbsolute $ Text.unpack . Purs.unSourcePath <$> allGlobs
   case shouldWatch of
     BuildOnce -> buildAction
-    Watch     -> Watch.watch (Set.fromAscList $ fmap Glob.compile absoluteGlobs) shouldClear buildAction
+    Watch -> do
+      matches <- liftIO $ checkGlobsExist absoluteGlobs
+      Watch.watch (Set.fromAscList $ fmap Glob.compile matches) shouldClear buildAction
+
+  where
+    checkGlobsExist :: [String] -> IO ([String], [String])
+    checkGlobsExist globs = do
+    
+    checkGlobExists :: String -> IO Bool
+    checkGlobExists pattern = do
+      paths <- Glob.glob pattern
+      pure $ null paths
+
 
 -- | Start a repl
 repl

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -88,17 +88,16 @@ build BuildOptions{..} maybePostBuild = do
   case shouldWatch of
     BuildOnce -> buildAction
     Watch -> do
-      matches <- liftIO $ checkGlobsExist absoluteGlobs
+      matches <- filterMatchingGlobs absoluteGlobs -- @TODO use allGlobs here
       Watch.watch (Set.fromAscList $ fmap Glob.compile matches) shouldClear buildAction
 
   where
-    checkGlobsExist :: [String] -> IO ([String], [String])
-    checkGlobsExist globs = do
-    
-    checkGlobExists :: String -> IO Bool
-    checkGlobExists pattern = do
-      paths <- Glob.glob pattern
-      pure $ null paths
+    filterMatchingGlobs :: Spago m => [String] -> m [String]
+    filterMatchingGlobs = filterM $ \pattern -> do
+      paths <- liftIO $ Glob.glob pattern
+      let matches = null paths
+      when matches $ echoStr $ "No match found for pattern: " ++ pattern
+      pure matches
 
 
 -- | Start a repl

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -81,20 +81,20 @@ build BuildOptions{..} maybePostBuild = do
     DoInstall -> Fetch.fetchPackages cacheConfig deps packagesMinPursVersion
     NoInstall -> pure ()
 
-  let allPSGlobs = Packages.getGlobs   deps depsOnly configSourcePaths <> sourcePaths
-      allJSGlobs = Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths
+  let allPsGlobs = Packages.getGlobs   deps depsOnly configSourcePaths <> sourcePaths
+      allJsGlobs = Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths
       buildAction globs = do
         Purs.compile globs pursArgs
         case maybePostBuild of
           Just action -> action
           Nothing     -> pure ()
 
-  absoluteJSGlobs <- makeGlobsAbsolute allJSGlobs
+  absoluteJSGlobs <- makeGlobsAbsolute allJsGlobs
 
   case shouldWatch of
-    BuildOnce -> buildAction allPSGlobs
+    BuildOnce -> buildAction allPsGlobs
     Watch -> do
-      matches <- filterMatchingGlobsAndWarn allPSGlobs
+      matches <- filterMatchingGlobsAndWarn allPsGlobs
       absolutePSGlobs <- makeGlobsAbsolute matches
       Watch.watch (Set.fromAscList $ fmap Glob.compile $ absolutePSGlobs <> absoluteJSGlobs) shouldClear (buildAction matches)
 

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -211,5 +211,9 @@ makeModuleCommandRenamed :: Text
 makeModuleCommandRenamed =
   "The `make-module` command has been replaced with `bundle-module`, so use that instead."
 
+globsDoNotMatchWhenWatching :: Text -> Text
+globsDoNotMatchWhenWatching pattern =
+  "WARNING: No matching files found when trying to watch pattern: " <> pattern
+
 makeMessage :: [Text] -> Text
 makeMessage = Text.intercalate "\n"

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -211,9 +211,9 @@ makeModuleCommandRenamed :: Text
 makeModuleCommandRenamed =
   "The `make-module` command has been replaced with `bundle-module`, so use that instead."
 
-globsDoNotMatchWhenWatching :: Text -> Text
-globsDoNotMatchWhenWatching pattern =
-  "WARNING: No matching files found when trying to watch pattern: " <> pattern
+globsDoNotMatchWhenWatching :: [Text] -> Text
+globsDoNotMatchWhenWatching patterns = makeMessage $
+  "WARNING: No matches found when trying to watch the following directories: " : patterns
 
 makeMessage :: [Text] -> Text
 makeMessage = Text.intercalate "\n"


### PR DESCRIPTION
### Description of the change

Fix #406 by checking that a glob matches some files before trying to watch them.

The varying combinations of `String`, `Text`, `FilePath` and `SourcePath` make the code a little hairy, but it seems to work 😅 

If you like we could actually do the `filterMatchingGlobsAndWarn` bit before the `BuildOnce`/`Watch` case statement, rather than relying on the compiler to warn the user.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] ~Added some example of the new feature to the `README`~
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
