### PR TITLE
Open generated docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Bugfixes:
 - "Quit" command in watch mode now actually quits (#390, #389)
 - Look up remote imports dynamically when doing frozen check (#349)
 
+New features:
+- Display a link to the generated docs' `index.html` (#379)
+- Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
+
 ## [0.9.0] - 2019-07-30
 
 Breaking changes (!!!):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+New features:
+- Display a link to the generated docs' `index.html` (#379)
+- Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
+
 ## [0.10.0] - 2019-09-21
 
 Breaking changes (!!!):
@@ -41,11 +45,6 @@ Other Improvements:
 - Docs: keep README up to date with new features (#398, #347)
 - Deps: upgrade to lts-14 and GHC-8.6 (#395)
 - Deps: upgrade to dhall-1.26.0, v10 of the standard (#411, #358)
-
-
-New features:
-- Display a link to the generated docs' `index.html` (#379)
-- Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
 
 ## [0.9.0] - 2019-07-30
 

--- a/README.md
+++ b/README.md
@@ -721,6 +721,11 @@ $ spago docs
 This will generate all the documentation in the `./generated-docs` folder of your project.
 You might then want to open the `index.html` file in there.
 
+If you wish for the documentation to be opened in browser when generated, you can pass an `open` flag:
+```bash
+$ spago docs --open
+```
+
 To build the documentation as Markdown instead of HTML, or to generate tags for your project,
 you can pass a `format` flag:
 ```bash

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -12,7 +12,8 @@ import qualified Turtle              as CLI
 
 import           Spago.Build         (BuildOptions (..), DepsOnly (..), ExtraArg (..),
                                       ModuleName (..), NoBuild (..), NoInstall (..), NoSearch (..),
-                                      SourcePath (..), TargetPath (..), Watch (..), WithMain (..))
+                                      SourcePath (..), TargetPath (..), Watch (..), WithMain (..),
+                                      OpenDocs (..))
 import qualified Spago.Build
 import qualified Spago.Config        as Config
 import           Spago.DryRun        (DryRun (..))
@@ -47,7 +48,7 @@ data Command
   | Repl (Maybe CacheFlag) [PackageName] [SourcePath] [ExtraArg] DepsOnly
 
   -- | Generate documentation for the project and its dependencies
-  | Docs (Maybe Purs.DocsFormat) [SourcePath] DepsOnly NoSearch
+  | Docs (Maybe Purs.DocsFormat) [SourcePath] DepsOnly NoSearch OpenDocs
 
   -- | Build the project paths src/ and test/ plus the specified source paths
   | Build BuildOptions
@@ -159,6 +160,7 @@ parser = do
     jsonFlag    = bool JsonOutputNo JsonOutputYes <$> CLI.switch "json" 'j' "Produce JSON output"
     dryRun      = bool DryRun NoDryRun <$> CLI.switch "no-dry-run" 'f' "Actually perform side-effects (the default is to describe what would be done)"
     usePsa      = bool UsePsa NoPsa <$> CLI.switch "no-psa" 'P' "Don't build with `psa`, but use `purs`"
+    openDocs    = bool NoOpenDocs DoOpenDocs <$> CLI.switch "open" 'o' "Open generated documentation in browswer (for HTML format only)"
     configPath  = CLI.optional $ CLI.optText "config" 'x' "Optional config path to be used instead of the default spago.dhall"
 
     mainModule  = CLI.optional $ CLI.opt (Just . ModuleName) "main" 'm' "Module to be used as the application's entry point"
@@ -235,7 +237,7 @@ parser = do
     docs =
       ( "docs"
       , "Generate docs for the project and its dependencies"
-      , Docs <$> docsFormat <*> sourcePaths <*> depsOnly <*> noSearch
+      , Docs <$> docsFormat <*> sourcePaths <*> depsOnly <*> noSearch <*> openDocs
       )
 
     search =
@@ -396,8 +398,8 @@ main = do
         -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions
       BundleModule modName tPath shouldBuild buildOptions
         -> Spago.Build.bundleModule modName tPath shouldBuild buildOptions
-      Docs format sourcePaths depsOnly noSearch
-        -> Spago.Build.docs format sourcePaths depsOnly noSearch
+      Docs format sourcePaths depsOnly noSearch openDocs
+        -> Spago.Build.docs format sourcePaths depsOnly noSearch openDocs
       Search                                -> Spago.Build.search
       Version                               -> printVersion
       PscPackageLocalSetup force            -> PscPackage.localSetup force

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,7 @@ library:
   - lens-family-core
   - mtl
   - network-uri
+  - open-browser
   - prettyprinter
   - process
   - retry

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -237,14 +237,6 @@ docs format sourcePaths depsOnly noSearch open = do
   Purs.docs docsFormat $ Packages.getGlobs deps depsOnly configSourcePaths <> sourcePaths
 
   when isHTMLFormat $ do
-    link <- linkToIndexHtml
-    let linkText = "Link: " <> link
-    echo linkText
-
-    when (open == DoOpenDocs) $ do
-      echo "Opening in browser..."
-      () <$ openLink link
-
     when (noSearch == AddSearch) $ do
       echo "Making the documentation searchable..."
       writeTextFile ".spago/purescript-docs-search" Templates.docsSearch
@@ -254,6 +246,14 @@ docs format sourcePaths depsOnly noSearch open = do
       shell cmd empty >>= \case
         ExitSuccess   -> pure ()
         ExitFailure n -> echo $ "Failed while trying to make the documentation searchable: " <> repr n
+        
+    link <- linkToIndexHtml
+    let linkText = "Link: " <> link
+    echo linkText
+
+    when (open == DoOpenDocs) $ do
+      echo "Opening in browser..."
+      () <$ openLink link
 
   where
     docsFormat = fromMaybe Purs.Html format

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -13,6 +13,7 @@ module Spago.Build
   , BuildOptions (..)
   , Packages.DepsOnly (..)
   , NoSearch (..)
+  , OpenDocs (..)
   , Purs.ExtraArg (..)
   , Purs.ModuleName (..)
   , Purs.SourcePath (..)
@@ -28,6 +29,7 @@ import qualified System.FilePath.Glob as Glob
 import qualified System.IO.Temp       as Temp
 import           System.Directory (getCurrentDirectory)
 import qualified Turtle               as Turtle
+import qualified Web.Browser          as Browser
 
 import qualified Spago.Config         as Config
 import qualified Spago.FetchPackage   as Fetch
@@ -209,6 +211,10 @@ bundleModule maybeModuleName maybeTargetPath noBuild buildOpts = do
 data NoSearch = NoSearch | AddSearch
   deriving (Eq)
 
+-- | Flag to open generated HTML documentation in browser
+data OpenDocs = NoOpenDocs | DoOpenDocs
+  deriving (Eq)
+
 -- | Generate docs for the `sourcePaths` and run `purescript-docs-search build-index` to patch them.
 docs
   :: Spago m
@@ -216,28 +222,33 @@ docs
   -> [Purs.SourcePath]
   -> Packages.DepsOnly
   -> NoSearch
+  -> OpenDocs
   -> m ()
-docs format sourcePaths depsOnly noSearch = do
+docs format sourcePaths depsOnly noSearch open = do
   echoDebug "Running `spago docs`"
   config@Config.Config{..} <- Config.ensureConfig
   deps <- Packages.getProjectDeps config
-  echo "Generating documentation for the project. This might take a while.."
+  echo "Generating documentation for the project. This might take a while..."
   Purs.docs docsFormat $ Packages.getGlobs deps depsOnly configSourcePaths <> sourcePaths
 
   when isHTMLFormat $ do
     link <- linkToIndexHtml
-    let text = "Link: " <> link
-    echo text
+    let linkText = "Link: " <> link
+    echo linkText
 
-  when (isHTMLFormat && noSearch == AddSearch) $ do
-    echo "Making the documentation searchable..."
-    writeTextFile ".spago/purescript-docs-search" Templates.docsSearch
-    writeTextFile ".spago/docs-search-app.js"     Templates.docsSearchApp
-    let cmd = "node .spago/purescript-docs-search build-index"
-    echoDebug $ "Running `" <> cmd <> "`"
-    shell cmd empty >>= \case
-      ExitSuccess   -> pure ()
-      ExitFailure n -> echo $ "Failed while trying to make the documentation searchable: " <> repr n
+    when (open == DoOpenDocs) $ do
+      echo "Opening in browser..."
+      () <$ openLink link
+
+    when (noSearch == AddSearch) $ do
+      echo "Making the documentation searchable..."
+      writeTextFile ".spago/purescript-docs-search" Templates.docsSearch
+      writeTextFile ".spago/docs-search-app.js"     Templates.docsSearchApp
+      let cmd = "node .spago/purescript-docs-search build-index"
+      echoDebug $ "Running `" <> cmd <> "`"
+      shell cmd empty >>= \case
+        ExitSuccess   -> pure ()
+        ExitFailure n -> echo $ "Failed while trying to make the documentation searchable: " <> repr n
 
   where
     docsFormat = fromMaybe Purs.Html format
@@ -246,6 +257,8 @@ docs format sourcePaths depsOnly noSearch = do
     linkToIndexHtml = do
       currentDir <- liftIO $ Text.pack <$> getCurrentDirectory
       return ("file://" <> currentDir <> "/generated-docs/html/index.html")
+    
+    openLink link = liftIO $ Browser.openBrowser (Text.unpack link)
 
 -- | Start a search REPL.
 search :: Spago m => m ()

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -82,6 +82,7 @@ data DocsFormat
   | Markdown
   | Ctags
   | Etags
+  deriving (Eq)
 
 parseDocsFormat :: Text -> Maybe DocsFormat
 parseDocsFormat = \case
@@ -92,7 +93,7 @@ parseDocsFormat = \case
   _          -> Nothing
 
 
-docs :: Spago m => Maybe DocsFormat -> [SourcePath] -> m ()
+docs :: Spago m => DocsFormat -> [SourcePath] -> m ()
 docs format sourcePaths = do
   let
     printDocsFormat :: DocsFormat -> Text
@@ -103,7 +104,7 @@ docs format sourcePaths = do
       Etags    -> "etags"
 
     paths = Text.intercalate " " $ surroundQuote <$> map unSourcePath sourcePaths
-    formatStr = printDocsFormat $ fromMaybe Html format
+    formatStr = printDocsFormat format
     cmd = "purs docs " <> paths <> " --format " <> formatStr
   runWithOutput cmd
     "Docs generation succeeded."


### PR DESCRIPTION
### Description of the change

Fixes #379.
Print a link to the `index.html` of the generated docs.
Add an `--open` flag to `spago docs` which opens them in browser upon generation.

Not sure how this can be tested though 🙂

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

