### PR TITLE
Add output folder sharing and `--no-share-output` flag to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ New features:
 - Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
 - Support building for alternate backends (#355). E.g: Use `backend = "psgo"` entry in `spago.dhall` to compile with `psgo`
 - Add `--no-comments` flag to `spago init` which strips comments from the generated `spago.dhall` and `packages.dhall` configs (#417)
+- Add shared output folder to reduce build duplication. Pass `--no-share-output` flag to `spago build` to disable (#377)
 
 Bugfixes:
 - Warn (but don't error) when trying to watch missing directories (#406)

--- a/README.md
+++ b/README.md
@@ -637,7 +637,9 @@ in upstream // overrides
 }
 ```
 
-To avoid building the same packages over and over, use `--sharedOutput` in `spago build` to use one `output` folder in the location of your root `packages.dhall` to speed up builds. In the example above, this would create an `output` folder in the root, instead of ending up with `lib1/output`, `lib2/output` etc.
+To avoid building the same packages over, a shared `output` folder will be created next to your root `packages.dhall`. 
+
+To disable this behaviour, pass `--no-share-output` to `spago build`.
 
 ### `devDependencies`, `testDependencies`, or in general a situation with many configurations
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ in upstream // overrides
 }
 ```
 
+To avoid building the same packages over and over, use `--sharedOutput` in `spago build` to use one `output` folder in the location of your root `packages.dhall` to speed up builds.
+
 ### `devDependencies`, `testDependencies`, or in general a situation with many configurations
 
 You might have a simpler situation than a monorepo, where e.g. you just want to "split" dependencies.

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ in upstream // overrides
 }
 ```
 
-To avoid building the same packages over and over, use `--sharedOutput` in `spago build` to use one `output` folder in the location of your root `packages.dhall` to speed up builds.
+To avoid building the same packages over and over, use `--sharedOutput` in `spago build` to use one `output` folder in the location of your root `packages.dhall` to speed up builds. In the example above, this would create an `output` folder in the root, instead of ending up with `lib1/output`, `lib2/output` etc.
 
 ### `devDependencies`, `testDependencies`, or in general a situation with many configurations
 

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -12,8 +12,8 @@ import qualified Turtle              as CLI
 
 import           Spago.Build         (BuildOptions (..), DepsOnly (..), ExtraArg (..),
                                       ModuleName (..), NoBuild (..), NoInstall (..), NoSearch (..),
-                                      OpenDocs (..), SourcePath (..), TargetPath (..),
-                                      UseSharedOutputFolder (..), Watch (..), WithMain (..))
+                                      OpenDocs (..), ShareOutput (..), SourcePath (..),
+                                      TargetPath (..), Watch (..), WithMain (..))
 import qualified Spago.Build
 import qualified Spago.Config        as Config
 import           Spago.Dhall         (TemplateComments (..))
@@ -155,7 +155,7 @@ parser = do
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
-    useSharedOutput = bool NoSharedOutput UseSharedOutputFolder <$> CLI.switch "sharedOutput" 'S' "Use shared output folder in location of packages.dhall"
+    useSharedOutput = bool ShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "Disabled using a shared output folder in location of root packages.dhall"
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly <*> useSharedOutput
 
     -- Note: by default we limit concurrency to 20

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -12,8 +12,8 @@ import qualified Turtle              as CLI
 
 import           Spago.Build         (BuildOptions (..), DepsOnly (..), ExtraArg (..),
                                       ModuleName (..), NoBuild (..), NoInstall (..), NoSearch (..),
-                                      OpenDocs (..), SourcePath (..), TargetPath (..), Watch (..),
-                                      WithMain (..))
+                                      OpenDocs (..), SourcePath (..), TargetPath (..),
+                                      UseSharedOutputFolder (..), Watch (..), WithMain (..))
 import qualified Spago.Build
 import qualified Spago.Config        as Config
 import           Spago.Dhall         (TemplateComments (..))
@@ -155,8 +155,8 @@ parser = do
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
-
-    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly
+    useSharedOutput = bool NoSharedOutput UseSharedOutputFolder <$> CLI.switch "sharedOutput" 'S' "Use shared output folder in location of packages.dhall"
+    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly <*> useSharedOutput
 
     -- Note: by default we limit concurrency to 20
     globalOptions = GlobalOptions <$> verbose <*> usePsa <*> fmap (fromMaybe 20) jobsLimit <*> fmap (fromMaybe Config.defaultPath) configPath

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -5,6 +5,7 @@ module Spago.PackageSet
   , freeze
   , ensureFrozen
   , packagesPath
+  , findRootOutputPath
   ) where
 
 import           Spago.Prelude
@@ -20,7 +21,7 @@ import           Spago.Messages      as Messages
 import qualified Spago.Purs          as Purs
 import qualified Spago.Templates     as Templates
 import qualified System.IO
-
+import qualified System.FilePath
 
 packagesPath :: IsString t => t
 packagesPath = "packages.dhall"
@@ -219,6 +220,32 @@ localImportPath (Dhall.Import
   })              = Just $ Text.unpack $ pretty localImport
 localImportPath _ = Nothing
 
+-- | In a Monorepo we don't wish to rebuild our shared packages over and over, 
+-- | so we build into an output folder at the highest point
+-- | (where, hopefully, packages.dhall lives)
+findRootOutputPath :: Spago m => System.IO.FilePath -> m (Maybe System.IO.FilePath)
+findRootOutputPath path = do
+  echoDebug "Locating root path of packages.dhall"
+  imports <- liftIO $ Dhall.readImports $ Text.pack path
+  let localImports = catMaybes (map localImportPath imports)
+  pure $ (flip System.FilePath.replaceFileName) "output" <$> (findRootPath localImports)
+
+-- | Given a list of filepaths, find the one with the least folders
+findRootPath :: [System.IO.FilePath] -> Maybe System.IO.FilePath
+findRootPath paths 
+  = foldr comparePaths Nothing paths
+  where
+    isLessThan :: Ord a => a -> Maybe a -> Bool
+    isLessThan a maybeA
+      = isNothing maybeA 
+      || fromMaybe False (fmap (\a' -> a < a') maybeA)
+    
+    comparePaths path current 
+      = if isLessThan 
+          (length (System.FilePath.splitSearchPath path))
+          (length <$> current)
+        then Just path
+        else current
 
 -- | Freeze the package set remote imports so they will be cached
 freeze :: Spago m => System.IO.FilePath -> m ()

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -237,7 +237,7 @@ findRootOutputPath :: Spago m => System.IO.FilePath -> m (Maybe System.IO.FilePa
 findRootOutputPath path = do
   echoDebug "Locating root path of packages.dhall"
   imports <- liftIO $ Dhall.readImports $ Text.pack path
-  let localImports = catMaybes (map rootPackagePath imports)
+  let localImports = mapMaybe rootPackagePath imports
   pure $ (flip System.FilePath.replaceFileName) "output" <$> (findRootPath localImports)
 
 -- | Given a list of filepaths, find the one with the least folders

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -429,6 +429,12 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       spago ["test"] >>= shouldBeSuccessOutput "test-output.txt"
 
+    it "Spago should test in custom output folder" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      spago ["test", "--purs-args", "-o", "--purs-args", "myOutput"] >>= shouldBeSuccess
+      testdir "myOutput" >>= (`shouldBe` True)
+
     it "Spago should test successfully with a different output folder" $ do
 
       -- Create root-level packages.dhall
@@ -450,6 +456,29 @@ spec = around_ setup $ do
 
       cd ".."
       testdir "output" >>= (`shouldBe` True)
+
+    it "Spago should test successfully with --no-share-output" $ do
+
+      -- Create root-level packages.dhall
+      mkdir "monorepo"
+      cd "monorepo"
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+
+      -- Create local 'lib-a' package that uses packages.dhall on top level (but also has it's own one to confuse things)
+      mkdir "lib-a"
+      cd "lib-a"
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+      writeTextFile "spago.dhall" $ "{ name = \"lib-1\", dependencies = [\"console\", \"effect\", \"prelude\"], packages = ./packages.dhall }"
+      rm "packages.dhall"
+      writeTextFile "packages.dhall" $ "../packages.dhall"
+      spago ["test", "--no-share-output"] >>= shouldBeSuccess
+      testdir "output" >>= (`shouldBe` True)
+
+      cd ".."
+      testdir "output" >>= (`shouldBe` False)
+
 
   describe "spago upgrade-set" $ do
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -5,7 +5,7 @@ import qualified Data.Text          as Text
 import           Prelude            hiding (FilePath)
 import qualified System.IO.Temp     as Temp
 import           Test.Hspec         (Spec, around_, describe, it, shouldBe, shouldNotSatisfy,
-                                     shouldSatisfy)
+                                     shouldReturn, shouldSatisfy)
 import           Turtle             (ExitCode (..), cd, cp, decodeString, empty, mkdir, mktree, mv,
                                      readTextFile, rm, shell, shellStrictWithErr, testdir,
                                      writeTextFile)
@@ -238,13 +238,13 @@ spec = around_ setup $ do
 
       spago ["init"] >>= shouldBeSuccess
       spago ["build", "--purs-args", "-o myOutput"] >>= shouldBeSuccess
-      testdir "myOutput" >>= (`shouldBe` True)
+      testdir "myOutput" `shouldReturn` True
 
     it "Spago should pass multiple options to purs" $ do
 
       spago ["init"] >>= shouldBeSuccess
       spago ["build", "--purs-args", "-o", "--purs-args", "myOutput"] >>= shouldBeSuccess
-      testdir "myOutput" >>= (`shouldBe` True)
+      testdir "myOutput" `shouldReturn` True
 
     it "Spago should build successfully with sources included from custom path" $ do
 
@@ -289,7 +289,7 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
       spago ["build", "--no-share-output"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
       cd ".."
       testdir "output" >>= (`shouldBe` False)
@@ -311,7 +311,7 @@ spec = around_ setup $ do
       rm "spago.dhall"
       writeTextFile "spago.dhall" $ "{ name = \"lib-1\", dependencies = [\"console\", \"effect\", \"prelude\"], packages = ./packages.dhall }"
       spago ["build", "--no-share-output"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
        -- Create local 'monorepo-3' package that uses packages.dhall on top level
       mkdir "monorepo-3"
@@ -322,13 +322,13 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../../packages.dhall"
       spago ["build"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
       cd ".."
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
       cd ".."
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
     it "Spago should find the middle packages.dhall even when another file is further up the tree" $ do
 
@@ -362,15 +362,15 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
 
       -- don't use nested folder
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
       -- use middle one
       cd ".."
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
       -- not the trick root folder
       cd ".."
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
     it "Spago should create an output folder in the root when we are not passing --no-share-output" $ do
 
@@ -389,10 +389,10 @@ spec = around_ setup $ do
       rm "spago.dhall"
       writeTextFile "spago.dhall" $ "{ name = \"lib-1\", dependencies = [\"console\", \"effect\", \"prelude\"], packages = ./packages.dhall }"
       spago ["build"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
       cd ".."
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
     describe "alternate backend" $ do
 
@@ -401,7 +401,6 @@ spec = around_ setup $ do
         spago ["init"] >>= shouldBeSuccess
         mv "spago.dhall" "spago-old.dhall"
         writeTextFile "spago.dhall" configWithBackend
-
 
         spago ["build"] >>= shouldBeSuccess
 
@@ -433,7 +432,7 @@ spec = around_ setup $ do
 
       spago ["init"] >>= shouldBeSuccess
       spago ["test", "--purs-args", "-o", "--purs-args", "myOutput"] >>= shouldBeSuccess
-      testdir "myOutput" >>= (`shouldBe` True)
+      testdir "myOutput" `shouldReturn` True
 
     it "Spago should test successfully with a different output folder" $ do
 
@@ -452,10 +451,10 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
       spago ["test"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
       cd ".."
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
     it "Spago should test successfully with --no-share-output" $ do
 
@@ -474,10 +473,10 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
       spago ["test", "--no-share-output"] >>= shouldBeSuccess
-      testdir "output" >>= (`shouldBe` True)
+      testdir "output" `shouldReturn` True
 
       cd ".."
-      testdir "output" >>= (`shouldBe` False)
+      testdir "output" `shouldReturn` False
 
 
   describe "spago upgrade-set" $ do

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -311,6 +311,7 @@ spec = around_ setup $ do
       rm "spago.dhall"
       writeTextFile "spago.dhall" $ "{ name = \"lib-1\", dependencies = [\"console\", \"effect\", \"prelude\"], packages = ./packages.dhall }"
       spago ["build", "--sharedOutput"] >>= shouldBeSuccess
+      testdir "output" >>= (`shouldBe` False)
 
       cd ".."
       testdir "output" >>= (`shouldBe` True)

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -429,6 +429,27 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       spago ["test"] >>= shouldBeSuccessOutput "test-output.txt"
 
+    it "Spago should test successfully with a different output folder" $ do
+
+      -- Create root-level packages.dhall
+      mkdir "monorepo"
+      cd "monorepo"
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+
+      -- Create local 'lib-a' package that uses packages.dhall on top level (but also has it's own one to confuse things)
+      mkdir "lib-a"
+      cd "lib-a"
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+      writeTextFile "spago.dhall" $ "{ name = \"lib-1\", dependencies = [\"console\", \"effect\", \"prelude\"], packages = ./packages.dhall }"
+      rm "packages.dhall"
+      writeTextFile "packages.dhall" $ "../packages.dhall"
+      spago ["test"] >>= shouldBeSuccess
+      testdir "output" >>= (`shouldBe` False)
+
+      cd ".."
+      testdir "output" >>= (`shouldBe` True)
 
   describe "spago upgrade-set" $ do
 

--- a/test/fixtures/run-no-psa.txt
+++ b/test/fixtures/run-no-psa.txt
@@ -8,7 +8,8 @@ Running `fetchPackages`
 Checking if `purs` is up to date
 Running `getGlobalCacheDir`
 Installation complete.
+Locating root path of packages.dhall
 Compiling with "purs"
-Running command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
+Running command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
 Writing .spago/run.js

--- a/test/fixtures/run-no-psa.txt
+++ b/test/fixtures/run-no-psa.txt
@@ -1,5 +1,6 @@
 🍝
 Running NodeJS
+Locating root path of packages.dhall
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen

--- a/test/fixtures/run-output-psa-not-installed.txt
+++ b/test/fixtures/run-output-psa-not-installed.txt
@@ -8,7 +8,8 @@ Running `fetchPackages`
 Checking if `purs` is up to date
 Running `getGlobalCacheDir`
 Installation complete.
+Locating root path of packages.dhall
 Compiling with "purs"
-Running command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
+Running command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
 Writing .spago/run.js

--- a/test/fixtures/run-output-psa-not-installed.txt
+++ b/test/fixtures/run-output-psa-not-installed.txt
@@ -1,5 +1,6 @@
 🍝
 Running NodeJS
+Locating root path of packages.dhall
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen

--- a/test/fixtures/run-output.txt
+++ b/test/fixtures/run-output.txt
@@ -8,7 +8,8 @@ Running `fetchPackages`
 Checking if `purs` is up to date
 Running `getGlobalCacheDir`
 Installation complete.
+Locating root path of packages.dhall
 Compiling with "psa"
-Running command: `psa compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
+Running command: `psa compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
 Writing .spago/run.js

--- a/test/fixtures/run-output.txt
+++ b/test/fixtures/run-output.txt
@@ -1,5 +1,6 @@
 🍝
 Running NodeJS
+Locating root path of packages.dhall
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen


### PR DESCRIPTION
### Description of the change

As per issue #377 building in a Monorepo ends creating a lot of duplication. This change adds a build flag `--sharedOutput` which will ask `purs` to output into the "root" folder (hopefully where the main `packages.dhall` lives, but basically the highest up source file in the tree that Dhall tells us about).

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [X] Added some example of the new feature to the `README`
- [X] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
