### PR TITLE
Fix `spago repl` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,10 @@ them after `--`.
 E.g. the following opens a repl on `localhost:3200`:
 
 ```bash
-$ spago repl --purs-args '--port 3200'
+$ spago repl -- --port 3200
+
+# or
+$ spago repl -- -p 3200
 ```
 
 


### PR DESCRIPTION
### Description of the change

There is no `--purs-args` (anymore?) but the section description is correct so I guess it just got left unchanged by accident.

Didn't touch the checklist below because I don't think any of them are applicable regarding this PR.

-------
Thank you all for your hard work!

-------
### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
