### PR TITLE
Make `spago verify-set` fail if there are duplicate module names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ New features:
 - Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
 - Support building for alternate backends (#355). E.g: Use `backend = "psgo"` entry in `spago.dhall` to compile with `psgo`
 - Add `--no-comments` flag to `spago init` which strips comments from the generated `spago.dhall` and `packages.dhall` configs (#417)
+- Make `spago verify-set` compile everything, to detect duplicate module names.
 
 Bugfixes:
 - Warn (but don't error) when trying to watch missing directories (#406)

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -12,6 +12,7 @@ module Spago.Packages
   , PackageSet.freeze
   , PackageSet.packagesPath
   , PackagesFilter(..)
+  , CheckModulesUnique(..)
   , JsonFlag(..)
   , DepsOnly(..)
   ) where
@@ -306,15 +307,16 @@ sources = do
   pure ()
 
 
-verify :: Spago m => Maybe CacheFlag -> Maybe PackageName -> m ()
-verify cacheFlag maybePackage = do
+data CheckModulesUnique = DoCheckModulesUnique | NoCheckModulesUnique
+
+verify :: Spago m => Maybe CacheFlag -> CheckModulesUnique -> Maybe PackageName -> m ()
+verify cacheFlag chkModsUniq maybePackage = do
   echoDebug "Running `spago verify`"
   Config{ packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfig
   case maybePackage of
     -- If no package is specified, verify all of them
     Nothing -> do
       verifyPackages packageSet (Map.toList packagesDB)
-      compileEverything packageSet
     -- In case we have a package, search in the package set for it
     Just packageName -> do
       case Map.lookup packageName packagesDB of
@@ -327,6 +329,9 @@ verify cacheFlag maybePackage = do
           reverseDeps <- liftIO $ getReverseDeps packageSet packageName
           let toVerify = [(packageName, package)] <> reverseDeps
           verifyPackages packageSet toVerify
+  case chkModsUniq of
+    DoCheckModulesUnique -> compileEverything packageSet
+    NoCheckModulesUnique -> pure ()
   where
     verifyPackages :: Spago m => PackageSet -> [(PackageName, Package)] -> m ()
     verifyPackages packageSet packages = do


### PR DESCRIPTION
This is needed for https://github.com/purescript/package-sets/issues/490

Note that `spago verify <package>` does _not_ do the check, only `spago verify-set` does. This is because the check requires downloading and compiling all packages, which would make `spago verify <package>` almost as slow as `spago verify-set`.

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)