### PR TITLE
Make `spago install purescript-*` install the package without prefix instead of just give warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,17 @@ Breaking changes (😱!!!):
   `psc-package-local-setup`, `psc-package-insdhall` and `psc-package-clean` commands.
 
 New features:
-- Display a link to the generated docs' `index.html` (#379)
-- Add `--open` flag to `spago docs` which opens generated docs in browser (#379)
-- Support building for alternate backends (#355). E.g: Use `backend = "psgo"` entry in `spago.dhall` to compile with `psgo`
-- Add `--no-comments` flag to `spago init` which strips comments from the generated `spago.dhall` and `packages.dhall` configs (#417)
-- Make `spago verify-set` compile everything, to detect duplicate module names (#438)
-- Add shared output folder to reduce build duplication. Pass `--no-share-output` flag to `spago build` to disable (#377)
-- Fix confusing warning when trying to `spago install` a package already present in project dependencies list (#436)
+- `spago docs` now displays a link to the generated docs' `index.html` (#379)
+- `spago docs` has new `--open` flag, which opens generated docs in browser (#379)
+- added support for building with alternate backends (#355). E.g: Use `backend = "psgo"` entry in `spago.dhall` to compile with `psgo`
+- `spago init` has new `--no-comments` flag which skips adding tutorial comments to the generated `spago.dhall` and `packages.dhall` files (#417)
+- `spago verify-set` now compiles everything, to detect duplicate module names (#438)
+- `spago build` now uses shared output folder to reduce build duplication. Pass `--no-share-output` flag to disable this behavior (#377)
+- `spago install purescript-XYZ` will now strip `purescript-` prefix and install XYZ (if it exists in package set) instead of just failing with a warning (#367)
 
 Bugfixes:
 - Warn (but don't error) when trying to watch missing directories (#406)
+- Fix confusing warning when trying to `spago install` a package already present in project dependencies list (#436)
 
 ## [0.10.0] - 2019-09-21
 

--- a/src/Spago/Dhall.hs
+++ b/src/Spago/Dhall.hs
@@ -61,12 +61,12 @@ readImports :: Text -> IO [Dhall.Import]
 readImports pathText = do
   fileContents <- readTextFile $ pathFromText pathText
   expr <- throws $ Parser.exprFromText mempty fileContents
-  (_, status) <- load expr
+  status <- load expr
   let graph = Lens.Family.view Dhall.Import.graph status
   pure $ childImport <$> graph
   where
     load expr
-      = State.runStateT
+      = State.execStateT
           (Dhall.Import.loadWith expr)
           (Dhall.Import.emptyStatus ".")
 

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -300,11 +300,10 @@ sources = do
   echoDebug "Running `spago sources`"
   config <- Config.ensureConfig
   deps <- getProjectDeps config
-  _ <- traverse echo
+  traverse_ echo
     $ fmap Purs.unSourcePath
     $ getGlobs deps AllSources
     $ Config.configSourcePaths config
-  pure ()
 
 
 data CheckModulesUnique = DoCheckModulesUnique | NoCheckModulesUnique
@@ -320,7 +319,7 @@ verify cacheFlag chkModsUniq maybePackage = do
     -- In case we have a package, search in the package set for it
     Just packageName -> do
       case Map.lookup packageName packagesDB of
-        Nothing -> die $ "No packages found with the name " <> Text.pack (show packageName)
+        Nothing -> die $ "No packages found with the name " <> tshow packageName
         -- When verifying a single package we check the reverse deps/referrers
         -- because we want to make sure the it doesn't break them
         -- (without having to check the whole set of course, that would work

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -76,9 +76,10 @@ shouldBeFailure result@(_code, _stdout, _stderr) = do
   result `shouldSatisfy` (\(code, _, _) -> code == ExitFailure 1)
 
 shouldBeFailureOutput :: HasCallStack => FilePath -> (ExitCode, Text, Text) -> IO ()
-shouldBeFailureOutput expected result = do
+shouldBeFailureOutput expected (code, _stdout, stderr) = do
   expectedContent <- readFixture expected
-  result `shouldSatisfy` (\(code, _stdout, stderr) -> code == ExitFailure 1 && stderr == expectedContent)
+  code `shouldBe` ExitFailure 1
+  stderr `shouldBe` expectedContent
 
 shouldBeFailureInfix :: HasCallStack => Text -> (ExitCode, Text, Text) -> IO ()
 shouldBeFailureInfix expected result = do

--- a/test/fixtures/spago-install-purescript-prefix-warning.txt
+++ b/test/fixtures/spago-install-purescript-prefix-warning.txt
@@ -1,0 +1,6 @@
+WARNING: the package 'purescript-newtype' was not found in your package set, but 'newtype' was. Using that instead.
+Installing 1 dependencies.
+Searching for packages cache metadata..
+Recent packages cache metadata found, using it..
+Copying from global cache: "newtype"
+Installation complete.


### PR DESCRIPTION
### Description of the change

This is my second attempt at improving the situation around https://github.com/spacchetti/spago/issues/367

In my first attempt (not published) I tried the approach you suggested in https://github.com/spacchetti/spago/issues/367#issuecomment-520241101:
I extended `getTransitiveDependencies` so that it can handle also `purescript-` prefix (by retrying failed lookup without the prefix). But this wasn't enough to fix the problem, because there were couple more places before that function is called which also lookup package in package set, which required further modifications.

I took a step back and looked at all the code which depends on `getTransitiveDependencies`.
Here's a diagram showing which top-level commands depend on it (arrow X->Y means function X is calling Y):
![getTransitiveDependencies](https://user-images.githubusercontent.com/2716069/66251090-794b0080-e74c-11e9-8681-f20c5f5cbf0e.png)


As you can see quite a lot of commands depend on getting transitive dependencies.
This made me think that perhaps we should fix this in some better place. Like we should sanitize user input before we even allow it into package set.

So the fix in this PR only makes `spago install purescript-XYZ` behave like you describe in the description.

I guess my question now is: **are there other commands / scenarios apart from `spago install`
 that exhibit some problems caused by not stripping `purescript-` prefix?**

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

