### PR TITLE
Speedup version bump tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Bugfixes:
 - Warn (but don't error) when trying to watch missing directories (#406)
 - Fix confusing warning when trying to `spago install` a package already present in project dependencies list (#436)
 
+Other improvements:
+- Speed up test suite by replacing couple of end 2 end bump-version tests with unit/property tests
+
 ## [0.10.0] - 2019-09-21
 
 Breaking changes (!!!):

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -118,14 +118,7 @@ parser = do
             "transitive" -> Just TransitiveDeps
             _            -> Nothing
       in CLI.optional $ CLI.opt wrap "filter" 'f' "Filter packages: direct deps with `direct`, transitive ones with `transitive`"
-    versionBump =
-      let spec = \case
-            "major" -> Just Spago.Version.Major
-            "minor" -> Just Spago.Version.Minor
-            "patch" -> Just Spago.Version.Patch
-            v | Right v' <- Spago.Version.parseVersion v -> Just $ Exact v'
-            _ -> Nothing
-      in CLI.arg spec "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
+    versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     force   = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
     verbose = CLI.switch "verbose" 'v' "Enable additional debug logging, e.g. printing `purs` commands"

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -326,7 +326,7 @@ main = do
   Env.setEnv "GIT_TERMINAL_PROMPT" "0"
 
   (command, globalOptions) <- CLI.options "Spago - manage your PureScript projects" parser
-  (flip runReaderT) globalOptions $
+  flip runReaderT globalOptions $
     case command of
       Init force noComments                 -> Spago.Packages.initProject force noComments
       Install cacheConfig packageNames      -> Spago.Packages.install cacheConfig packageNames

--- a/package.yaml
+++ b/package.yaml
@@ -150,3 +150,4 @@ tests:
     - temporary
     - text < 1.3
     - turtle
+    - versions

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -66,19 +66,18 @@ getCurrentVersion = do
       pure maxVersion
 
 
--- | Get the next version to use, or die if this would result in the version number going down/not changing.
 getNextVersion :: VersionBump -> SemVer -> Either Text SemVer
-getNextVersion spec version@SemVer{..} =
+getNextVersion spec currentV@SemVer{..} =
   case spec of
     Major -> Right $ SemVer (_svMajor + 1) 0 0 [] []
     Minor -> Right $ SemVer _svMajor (_svMinor + 1) 0 [] []
     Patch -> Right $ SemVer _svMajor _svMinor (_svPatch + 1) [] []
-    Exact v
-      | v > version -> Right v
+    Exact newV
+      | currentV < newV -> Right newV
       | otherwise -> do
-        let new = unparseVersion v
-            old = unparseVersion version
-        Left $ "The new version (" <> new <> ") must be higher than the current version (" <> old <> ")"
+        let new = unparseVersion newV
+            current = unparseVersion currentV
+        Left $ "The new version (" <> new <> ") must be higher than the current version (" <> current <> ")"
 
 
 -- | Make a tag for the new version.

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -2,7 +2,8 @@ module Spago.Version
   ( VersionBump(..)
   , DryRun(..)
   , bumpVersion
-  , parseVersion
+  , getNextVersion
+  , parseVersionBump
   , unparseVersion
   ) where
 
@@ -24,6 +25,15 @@ data VersionBump
   | Minor
   | Patch
   | Exact SemVer
+
+
+parseVersionBump :: Text -> Maybe VersionBump
+parseVersionBump = \case
+  "major" -> Just Major
+  "minor" -> Just Minor
+  "patch" -> Just Patch
+  v | Right v' <- parseVersion v -> Just $ Exact v'
+  _ -> Nothing
 
 
 -- | Parses a version, ignoring an optional leading 'v', or returns an error message.

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -2,7 +2,7 @@ module BumpVersionSpec (spec) where
 
 import           Prelude        hiding (FilePath)
 import qualified System.IO.Temp as Temp
-import           Test.Hspec     (Spec, around_, before_, describe, it, shouldBe)
+import           Test.Hspec     (Spec, around_, before_, describe, it, shouldReturn)
 import           Turtle         (Text, cp, decodeString, mkdir, mv, writeTextFile)
 import           Utils          (checkFileHasInfix, checkFixture, getHighestTag, git,
                                  shouldBeFailure, shouldBeFailureInfix, shouldBeSuccess, spago,
@@ -66,32 +66,32 @@ spec = around_ setup $ do
     before_ (initGitTag "v1.2.3") $ it "Spago should not make a tag when not passing --no-dry-run" $ do
 
       spago ["bump-version", "minor"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v1.2.3")
+      getHighestTag `shouldReturn` Just "v1.2.3"
 
     before_ (initGitTag "not-a-version") $ it "Spago should use v0.0.0 as initial version" $ do
 
       spago ["bump-version", "--no-dry-run", "patch"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v0.0.1")
+      getHighestTag `shouldReturn` Just "v0.0.1"
 
     before_ (initGitTag "v1.3.4") $ it "Spago should bump patch version" $ do
 
       spago ["bump-version", "--no-dry-run", "patch"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v1.3.5")
+      getHighestTag `shouldReturn` Just "v1.3.5"
 
     before_ (initGitTag "v1.3.4") $ it "Spago should bump minor version" $ do
 
       spago ["bump-version", "--no-dry-run", "minor"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v1.4.0")
+      getHighestTag `shouldReturn` Just "v1.4.0"
 
     before_ (initGitTag "v1.3.4") $ it "Spago should bump major version" $ do
 
       spago ["bump-version", "--no-dry-run", "major"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v2.0.0")
+      getHighestTag `shouldReturn` Just "v2.0.0"
 
     before_ (initGitTag "v0.0.1") $ it "Spago should set exact version" $ do
 
       spago ["bump-version", "--no-dry-run", "v3.1.5"] >>= shouldBeSuccess
-      getHighestTag >>= (`shouldBe` Just "v3.1.5")
+      getHighestTag `shouldReturn` Just "v3.1.5"
 
     before_ initGit $ it "Spago should create bower.json, but not commit it" $ do
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -24,15 +24,13 @@ import           Prelude            hiding (FilePath)
 import           System.Directory   (removePathForcibly)
 import qualified System.Process     as Process
 import           Test.Hspec         (HasCallStack, shouldBe, shouldSatisfy)
-import           Turtle             (ExitCode (..), FilePath, Text, cd, empty,
-                                     encodeString, inproc, limit,
-                                     procStrictWithErr, pwd, readTextFile,
-                                     strict)
+import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString, inproc,
+                                     limit, procStrictWithErr, pwd, readTextFile, strict)
 
 withCwd :: FilePath -> IO () -> IO ()
 withCwd dir cmd = do
   oldDir <- pwd
-  Exception.bracket (cd dir) (const $ cd oldDir) (const cmd)
+  Exception.bracket_ (cd dir) (cd oldDir) cmd
 
 spago :: [Text] -> IO (ExitCode, Text, Text)
 spago args =


### PR DESCRIPTION
### Description of the change

Attempt to speed up test suite by focusing on the slowest tests as described in https://github.com/spacchetti/spago/issues/440

Locally this change seems to have shaved off ~20s of test running time.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)
