### PR TITLE
Fix hlint warnings

### DIFF
--- a/src/Spago/Bower.hs
+++ b/src/Spago/Bower.hs
@@ -47,7 +47,7 @@ runBower args = do
 
 generateBowerJson :: Spago m => m ByteString.ByteString
 generateBowerJson = do
-  echo $ "Generating a new Bower config using the package set versions.."
+  echo "Generating a new Bower config using the package set versions.."
   config@Config{..} <- Config.ensureConfig
   PublishConfig{..} <- throws publishConfig
 
@@ -68,7 +68,7 @@ generateBowerJson = do
   when ignored $ do
     die $ path <> " is being ignored by git - change this before continuing"
 
-  echo $ "Generated a valid Bower config using the package set"
+  echo "Generated a valid Bower config using the package set"
   pure bowerJson
 
 

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -32,7 +32,7 @@ import           System.Directory     (getCurrentDirectory)
 import qualified System.FilePath.Glob as Glob
 import qualified System.IO            as Sys
 import qualified System.IO.Temp       as Temp
-import qualified Turtle               as Turtle
+import qualified Turtle
 import qualified Web.Browser          as Browser
 
 import qualified Spago.Config         as Config
@@ -204,16 +204,16 @@ runWithNode defaultModuleName maybeSuccessMessage failureMessage maybeModuleName
   where
     moduleName = fromMaybe defaultModuleName maybeModuleName
     args = Text.intercalate " " $ map Purs.unExtraArg nodeArgs
-    contents = \outputPath'
-      -> let path = fromMaybe "output" outputPath'
+    contents outputPath' =
+         let path = fromMaybe "output" outputPath'
          in "#!/usr/bin/env node\n\n" <> "require('../" <> Text.pack path <> "/" <> Purs.unModuleName moduleName <> "').main()"
     cmd = "node .spago/run.js " <> args
     nodeAction outputPath' = do
-      echoDebug $ "Writing .spago/run.js"
+      echoDebug "Writing .spago/run.js"
       writeTextFile ".spago/run.js" (contents outputPath')
       chmod executable ".spago/run.js"
       shell cmd empty >>= \case
-        ExitSuccess   -> fromMaybe (pure ()) (echo <$> maybeSuccessMessage)
+        ExitSuccess   -> maybe (pure ()) echo maybeSuccessMessage
         ExitFailure n -> die $ failureMessage <> repr n
 
   -- | Bundle the project to a js file
@@ -250,7 +250,7 @@ bundleModule maybeModuleName maybeTargetPath noBuild buildOpts = do
         -- Here we append the CommonJS export line at the end of the bundle
         try (with
               (appendonly $ pathFromText $ Purs.unTargetPath targetPath)
-              ((flip hPutStrLn) jsExport))
+              (flip hPutStrLn jsExport))
           >>= \case
             Right _ -> echo $ "Make module succeeded and output file to " <> Purs.unTargetPath targetPath
             Left (n :: SomeException) -> die $ "Make module failed: " <> repr n
@@ -351,7 +351,7 @@ getOutputPath buildOpts = do
 -- | which should be the output folder
 findOutputFlag :: [Purs.ExtraArg] -> Maybe Sys.FilePath
 findOutputFlag [] = Nothing
-findOutputFlag (_:[]) = Nothing
+findOutputFlag [_] = Nothing
 findOutputFlag (x:y:xs)
   = if isOutputFlag x
     then Just $ Text.unpack (Purs.unExtraArg y)
@@ -378,8 +378,8 @@ getBuildArgsForSharedFolder buildOpts = do
   let pursArgs'
         = pursArgs buildOpts
       pathToOutputArg
-        = Purs.ExtraArg . Text.pack . ((++) "--output ")
-  if (or $ isOutputFlag <$> pursArgs')
+        = Purs.ExtraArg . Text.pack . ("--output " <>)
+  if any isOutputFlag pursArgs'
     then do
       echo "Output path set explicitly - not using shared output path"
       pure pursArgs'

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -135,14 +135,14 @@ parseConfig = do
       let metadataPackageName = PackageSet.PackageName "metadata"
       let (metadataMap, packagesDB) = Map.partitionWithKey (\k _v -> k == metadataPackageName) packages
       let packagesMinPursVersion = join
-            $ fmap (hush . Version.semver . (Text.replace "v" "") . PackageSet.version . PackageSet.location)
+            $ fmap (hush . Version.semver . Text.replace "v" "" . PackageSet.version . PackageSet.location)
             $ Map.lookup metadataPackageName metadataMap
       let packageSet = PackageSet.PackageSet{..}
 
       pure Config{..}
     _ -> case Dhall.TypeCheck.typeOf expr of
       Right e  -> throwM $ Dhall.ConfigIsNotRecord e
-      Left err -> throwM $ err
+      Left err -> throwM err
 
 
 -- | Checks that the Spago config is there and readable
@@ -151,7 +151,7 @@ ensureConfig = do
   path <- asks globalConfigPath
   exists <- testfile path
   unless exists $ do
-    die $ Messages.cannotFindConfig
+    die Messages.cannotFindConfig
   try parseConfig >>= \case
     Right config -> do
       PackageSet.ensureFrozen $ Text.unpack path
@@ -258,7 +258,7 @@ showBowerErrors (List.sort -> errors)
   = "\n\nSpago encountered some errors while trying to migrate your Bower config.\n"
   <> "A Spago config has been generated but it's recommended that you apply the suggestions here\n\n"
   <> (Text.unlines $ map (\errorGroup ->
-      (case (head errorGroup) of
+      (case head errorGroup of
          UnparsableRange _ _ -> "It was not possible to parse the version range for these packages:"
          NonPureScript _ -> "These packages are not PureScript packages, so you should install them with `npm` instead:"
          MissingFromTheSet _ -> "These packages are missing from the package set. You should add them in your local package set:\n(See here for how: https://github.com/spacchetti/spago#add-a-package-to-the-package-set)"

--- a/src/Spago/Dhall.hs
+++ b/src/Spago/Dhall.hs
@@ -82,7 +82,7 @@ readRawExpr pathText = do
     then (do
       packageSetText <- readTextFile $ pathFromText pathText
       fmap Just $ throws $ Parser.exprAndHeaderFromText mempty packageSetText)
-    else (pure Nothing)
+    else pure Nothing
 
 
 writeRawExpr :: Text -> (Text, DhallExpr Dhall.Import) -> IO ()
@@ -117,7 +117,7 @@ requireKey
   -> Text
   -> (DhallExpr b -> m a)
   -> m a
-requireKey ks name f = case (Dhall.Map.lookup name ks) of
+requireKey ks name f = case Dhall.Map.lookup name ks of
   Just v  -> f v
   Nothing -> throwM (RequiredKeyMissing name ks)
 
@@ -198,7 +198,7 @@ instance (Pretty a) => Show (ReadError a) where
         , ""
         , "The type was the following:"
         , ""
-        , "↳ " <> (pretty $ Dhall.expected typ)
+        , "↳ " <> pretty (Dhall.expected typ)
         , ""
         , "And the expression was the following:"
         , ""

--- a/src/Spago/PackageSet.hs
+++ b/src/Spago/PackageSet.hs
@@ -10,18 +10,20 @@ module Spago.PackageSet
 
 import           Spago.Prelude
 
-import qualified Data.Text           as Text
-import qualified Data.Versions       as Version
+import           Data.Ord        (comparing)
+import qualified Data.Text       as Text
+import qualified Data.Versions   as Version
 import qualified Dhall.Freeze
 import qualified Dhall.Pretty
+import qualified Safe
 
-import qualified Spago.Dhall         as Dhall
-import qualified Spago.GitHub        as GitHub
-import           Spago.Messages      as Messages
-import qualified Spago.Purs          as Purs
-import qualified Spago.Templates     as Templates
-import qualified System.IO
+import qualified Spago.Dhall     as Dhall
+import qualified Spago.GitHub    as GitHub
+import           Spago.Messages  as Messages
+import qualified Spago.Purs      as Purs
+import qualified Spago.Templates as Templates
 import qualified System.FilePath
+import qualified System.IO
 
 packagesPath :: IsString t => t
 packagesPath = "packages.dhall"
@@ -64,7 +66,7 @@ upgradePackageSet = do
         Nothing -> die Messages.cannotFindPackages
         -- Skip the check if the tag is already the newest
         Just (_, expr)
-          | (currentTag:_) <- (foldMap getCurrentTag expr)
+          | (currentTag:_) <- foldMap getCurrentTag expr
           , currentTag == releaseTagName
             -> echo $ "Skipping package set version upgrade, already on latest version: " <> quotedTag
         Just (header, expr) -> do
@@ -231,31 +233,18 @@ rootPackagePath (Dhall.Import
 rootPackagePath _ = Nothing
 
 
--- | In a Monorepo we don't wish to rebuild our shared packages over and over, 
+-- | In a Monorepo we don't wish to rebuild our shared packages over and over,
 -- | so we build into an output folder where our root packages.dhall lives
 findRootOutputPath :: Spago m => System.IO.FilePath -> m (Maybe System.IO.FilePath)
 findRootOutputPath path = do
   echoDebug "Locating root path of packages.dhall"
   imports <- liftIO $ Dhall.readImports $ Text.pack path
   let localImports = mapMaybe rootPackagePath imports
-  pure $ (flip System.FilePath.replaceFileName) "output" <$> (findRootPath localImports)
+  pure $ flip System.FilePath.replaceFileName "output" <$> findRootPath localImports
 
 -- | Given a list of filepaths, find the one with the least folders
 findRootPath :: [System.IO.FilePath] -> Maybe System.IO.FilePath
-findRootPath paths 
-  = foldr comparePaths Nothing paths
-  where
-    isLessThan :: Ord a => a -> Maybe a -> Bool
-    isLessThan a maybeA
-      = isNothing maybeA 
-      || fromMaybe False (fmap (\a' -> a < a') maybeA)
-
-    comparePaths path current 
-      = if isLessThan 
-          (length (System.FilePath.splitSearchPath path))
-          (length <$> current)
-        then Just path
-        else current
+findRootPath = Safe.minimumByMay (comparing (length . System.FilePath.splitSearchPath))
 
 -- | Freeze the package set remote imports so they will be cached
 freeze :: Spago m => System.IO.FilePath -> m ()

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -82,7 +82,7 @@ initProject force comments = do
           action
 
     copyIfNotExists dest srcTemplate = do
-      (testfile dest) >>= \case
+      testfile dest >>= \case
         True  -> echo $ Messages.foundExistingFile dest
         False -> writeTextFile dest srcTemplate
 
@@ -272,7 +272,7 @@ listPackages packagesFilter jsonFlag = do
   echoDebug "Running `listPackages`"
   Config{packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfig
   packagesToList :: [(PackageName, Package)] <- case packagesFilter of
-    Nothing             -> pure $ Map.toList $ packagesDB
+    Nothing             -> pure $ Map.toList packagesDB
     Just TransitiveDeps -> getTransitiveDeps packageSet dependencies
     Just DirectDeps     -> pure $ Map.toList
       $ Map.restrictKeys packagesDB (Set.fromList dependencies)

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -89,7 +89,7 @@ import           Dhall                                 (Text)
 import qualified Dhall.Core
 import qualified System.FilePath                       as FilePath
 import qualified System.IO
-import qualified Turtle                                as Turtle
+import qualified Turtle
 import qualified UnliftIO.Directory                    as Directory
 
 import           Control.Applicative                   (Alternative, empty, many, (<|>))
@@ -120,8 +120,9 @@ import           Safe                                  (headMay)
 import           System.FilePath                       (isAbsolute, pathSeparator, (</>))
 import           System.IO                             (hPutStrLn)
 import           Turtle                                (ExitCode (..), FilePath, appendonly, chmod,
-                                                        executable, mktree, repr, shell, shellStrict,
-                                                        shellStrictWithErr, systemStrictWithErr, testdir)
+                                                        executable, mktree, repr, shell,
+                                                        shellStrict, shellStrictWithErr,
+                                                        systemStrictWithErr, testdir)
 import           UnliftIO                              (MonadUnliftIO, withRunInIO)
 import           UnliftIO.Directory                    (getModificationTime, makeAbsolute)
 import           UnliftIO.Exception                    (IOException, handleAny, try, tryIO)

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -75,7 +75,7 @@ bundle withMain (ModuleName moduleName) (TargetPath targetPath) = do
 
   runWithOutput cmd
     ("Bundle succeeded and output file to " <> targetPath)
-    ("Bundle failed.")
+    "Bundle failed."
 
 
 data DocsFormat
@@ -120,8 +120,8 @@ versionImpl purs = do
   fullVersionText <- shellStrictWithErr (purs <> " --version") empty >>= \case
     (ExitSuccess, out, _err) -> pure out
     (_, _out, err) -> die $ "Failed to run '" <> purs <> " --version'. Error:" <> err
-  versionText <- pure $ headMay $ Text.split (== ' ') fullVersionText
-  parsed <- pure $ versionText >>= (hush . Version.semver)
+  let versionText = headMay $ Text.split (== ' ') fullVersionText
+      parsed = versionText >>= (hush . Version.semver)
 
   when (isNothing parsed) $ do
     echo $ Messages.failedToParseCommandOutput (purs <> " --version") fullVersionText

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -4,7 +4,7 @@ import           Spago.Prelude
 
 import qualified Data.Text      as Text
 import qualified Data.Versions  as Version
-import qualified Dhall          as Dhall
+import qualified Dhall
 import qualified Network.URI    as URI
 
 import qualified Spago.Messages as Messages

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -80,11 +80,10 @@ fileWatchConf watchConfig shouldClear inner = withManagerConf watchConfig $ \man
             -- and the last event either has different path, or has happened
             -- more than `debounceTime` seconds ago.
             let shouldRebuild =
-                  ( or (matches <$> Set.toList globs)
+                   any matches (Set.toList globs)
                  && ( lastPath /= Watch.eventPath event
                    || diffUTCTime timeNow lastTime > debounceTime
                     )
-                  )
 
             when shouldRebuild
               (writeTVar dirtyVar True)
@@ -129,13 +128,13 @@ fileWatchConf watchConfig shouldClear inner = withManagerConf watchConfig $ \man
               return Nothing
 
             startListening = Map.mapWithKey $ \dir () -> do
-              listen <- Watch.watchTree manager dir (const True) $ onChange
+              listen <- Watch.watchTree manager dir (const True) onChange
               return $ Just listen
 
     let watchInput :: Spago m => m ()
         watchInput = do
           line <- liftIO $ unpack . toLower . pack <$> getLine
-          if (line == "quit") then echo "Leaving watch mode."
+          if line == "quit" then echo "Leaving watch mode."
           else do
             liftIO $ case line of
               "help" -> do

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -506,7 +506,7 @@ spec = around_ setup $ do
             $ Text.lines packages
       writeTextFile "packages.dhall" "https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190713/src/packages.dhall sha256:906af79ba3aec7f429b107fd8d12e8a29426db8229d228c6f992b58151e2308e"
       spago ["-v", "upgrade-set"] >>= shouldBeSuccess
-      newPackages <- fmap Text.strip $ readTextFile "packages.dhall"
+      newPackages <- Text.strip <$> readTextFile "packages.dhall"
       newPackages `shouldBe` packageSetUrl
 
 


### PR DESCRIPTION
### Description of the change

I fixed relatively conservative subset of hlint warnings which IMO make the code more lightweight/readable by removing some redundancies (unnecessary parens, import aliases, using better functions where available etc.)

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
