### PR TITLE
Add support for `spago run` with alternative backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ New features:
 - `spago verify-set` now compiles everything, to detect duplicate module names (#438)
 - `spago build` now uses shared output folder to reduce build duplication. Pass `--no-share-output` flag to disable this behavior (#377)
 - `spago install purescript-XYZ` will now strip `purescript-` prefix and install XYZ (if it exists in package set) instead of just failing with a warning (#367)
+- `spago run` now recognizes backend specified in the configuration file and calls the backend with `--run` argument.
 
 Bugfixes:
 - Warn (but don't error) when trying to watch missing directories (#406)

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -181,42 +181,51 @@ repl cacheFlag newPackages sourcePaths pursArgs depsOnly = do
 -- | Test the project: compile and run "Test.Main"
 --   (or the provided module name) with node
 test :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> [Purs.ExtraArg] -> m ()
-test = runWithNode (Purs.ModuleName "Test.Main") (Just "Tests succeeded.") "Tests failed: "
+test maybeModuleName buildOpts extraArgs = do
+  Config.Config { alternateBackend } <- Config.ensureConfig
+  runBackend alternateBackend (Purs.ModuleName "Test.Main") (Just "Tests succeeded.") "Tests failed: " maybeModuleName buildOpts extraArgs
 
 -- | Run the project: compile and run "Main"
 --   (or the provided module name) with node
 run :: Spago m => Maybe Purs.ModuleName -> BuildOptions -> [Purs.ExtraArg] -> m ()
-run = runWithNode (Purs.ModuleName "Main") Nothing "Running failed, exit code: "
+run maybeModuleName buildOpts extraArgs = do
+  Config.Config { alternateBackend } <- Config.ensureConfig
+  runBackend alternateBackend (Purs.ModuleName "Main") Nothing "Running failed; " maybeModuleName buildOpts extraArgs
 
 -- | Run the project with node: compile and run with the provided ModuleName
 --   (or the default one if that's missing)
-runWithNode
+runBackend
   :: Spago m
-  => Purs.ModuleName
+  => Maybe Text
+  -> Purs.ModuleName
   -> Maybe Text
   -> Text
   -> Maybe Purs.ModuleName
   -> BuildOptions
   -> [Purs.ExtraArg]
   -> m ()
-runWithNode defaultModuleName maybeSuccessMessage failureMessage maybeModuleName buildOpts nodeArgs = do
-  echoDebug "Running NodeJS"
-  outputPath <- getOutputPath buildOpts
-  build buildOpts (Just (nodeAction outputPath))
+runBackend maybeBackend defaultModuleName maybeSuccessMessage failureMessage maybeModuleName buildOpts extraArgs = do
+  echoDebug $ "Running with backend: " <> fromMaybe "nodejs" maybeBackend
+  let postBuild = maybe (nodeAction =<< getOutputPath buildOpts) backendAction maybeBackend
+  build buildOpts (Just postBuild)
   where
     moduleName = fromMaybe defaultModuleName maybeModuleName
-    args = Text.intercalate " " $ map Purs.unExtraArg nodeArgs
-    contents outputPath' =
+    nodeArgs = Text.intercalate " " $ map Purs.unExtraArg extraArgs
+    nodeContents outputPath' =
          let path = fromMaybe "output" outputPath'
          in "#!/usr/bin/env node\n\n" <> "require('../" <> Text.pack path <> "/" <> Purs.unModuleName moduleName <> "').main()"
-    cmd = "node .spago/run.js " <> args
+    nodeCmd = "node .spago/run.js " <> nodeArgs
     nodeAction outputPath' = do
       echoDebug "Writing .spago/run.js"
-      writeTextFile ".spago/run.js" (contents outputPath')
+      writeTextFile ".spago/run.js" (nodeContents outputPath')
       chmod executable ".spago/run.js"
-      shell cmd empty >>= \case
+      shell nodeCmd empty >>= \case
         ExitSuccess   -> maybe (pure ()) echo maybeSuccessMessage
-        ExitFailure n -> die $ failureMessage <> repr n
+        ExitFailure n -> die $ failureMessage <> "exit code: " <> repr n
+    backendAction backend =
+      Turtle.proc backend (["--run" {-, Purs.unModuleName moduleName-}] <> fmap Purs.unExtraArg extraArgs) empty >>= \case
+        ExitSuccess   -> maybe (pure ()) echo maybeSuccessMessage
+        ExitFailure n -> die $ failureMessage <> "Backend " <> surroundQuote backend <> " exited with error:" <> repr n
 
   -- | Bundle the project to a js file
 bundleApp

--- a/test/fixtures/run-no-psa.txt
+++ b/test/fixtures/run-no-psa.txt
@@ -1,6 +1,7 @@
 🍝
-Running NodeJS
-Locating root path of packages.dhall
+Transformed config is the same as the read one, not overwriting it
+Ensuring that the package set is frozen
+Running with backend: nodejs
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
@@ -13,4 +14,5 @@ Locating root path of packages.dhall
 Compiling with "purs"
 Running command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
+Locating root path of packages.dhall
 Writing .spago/run.js

--- a/test/fixtures/run-output-psa-not-installed.txt
+++ b/test/fixtures/run-output-psa-not-installed.txt
@@ -1,6 +1,7 @@
 🍝
-Running NodeJS
-Locating root path of packages.dhall
+Transformed config is the same as the read one, not overwriting it
+Ensuring that the package set is frozen
+Running with backend: nodejs
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
@@ -13,4 +14,5 @@ Locating root path of packages.dhall
 Compiling with "purs"
 Running command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
+Locating root path of packages.dhall
 Writing .spago/run.js

--- a/test/fixtures/run-output.txt
+++ b/test/fixtures/run-output.txt
@@ -1,6 +1,7 @@
 🍝
-Running NodeJS
-Locating root path of packages.dhall
+Transformed config is the same as the read one, not overwriting it
+Ensuring that the package set is frozen
+Running with backend: nodejs
 Running `spago build`
 Transformed config is the same as the read one, not overwriting it
 Ensuring that the package set is frozen
@@ -13,4 +14,5 @@ Locating root path of packages.dhall
 Compiling with "psa"
 Running command: `psa compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`
 Build succeeded.
+Locating root path of packages.dhall
 Writing .spago/run.js


### PR DESCRIPTION
### Description of the change

- Made `spago run` call the backend with `--run` argument.
- Updated `spago run` specs for node backend.
- `spago test` still uses node backend.

As for the test, if creating a shell script and a batch file to echo $1 to check backend arg is the way to go, I'll be happy to implement it.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)