### PR TITLE
Improve cache skipping warning

### DIFF
--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -65,7 +65,7 @@ globallyCache (packageName, Repo url, ref) downloadDir metadata cacheableCallbac
           cacheableCallback $ Turtle.encodeString resultDir
       where
     _ -> do
-      echo $ "Warning: was not able to match url with GitHub ones: " <> url
+      echo $ "WARNING: Not caching repo, because URL doesn't have the form of 'https://github.com/<ORG>/<REPO>.git': " <> url
       notCacheableCallback -- TODO: error?
   where
     isTag = do
@@ -138,7 +138,7 @@ getMetadata cacheFlag = do
 
 
 -- | Directory in which spago will put its global cache
---   `getXdgDirectory XdgCache` tries to find the folder pointed by 
+--   `getXdgDirectory XdgCache` tries to find the folder pointed by
 --   `$XDG_CACHE_HOME`, otherwise it uses:
 --   - (on Linux/MacOS) the folder pointed by `$HOME/.cache`, or
 --   - (on Windows) the folder pointed by `LocalAppData`

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -80,7 +80,7 @@ fileWatchConf watchConfig shouldClear inner = withManagerConf watchConfig $ \man
             -- and the last event either has different path, or has happened
             -- more than `debounceTime` seconds ago.
             let shouldRebuild =
-                   any matches (Set.toList globs)
+                   any matches globs
                  && ( lastPath /= Watch.eventPath event
                    || diffUTCTime timeNow lastTime > debounceTime
                     )


### PR DESCRIPTION
### Description of the change

Fix 3 problems with this warning :smile: 
- is not actionable (not clear how user can fix this)
- it's not clear what problems the wrongly formatted causes to spago (the package won't be cached locally) 
- it's written as `"Warning"` where all the other warnings have `"WARNING"`

(sidenote: also fixed the url in the package-set: https://github.com/purescript/package-sets/pull/514)

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
