### PR TITLE
Always run the test suite with UTF8 encoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,15 +83,6 @@ $ npm install -g bower
 $ stack test
 ```
 
-note: if you receive the following error from running tests: 
-hGetContents: invalid argument (invalid byte sequence)
-
-You may be missing an environment variable. try the following
-
-```bash
-$ LC_ALL=en_US.iso88591 
-$ stack test
-```
 
 ## Merging changes
 

--- a/package.yaml
+++ b/package.yaml
@@ -155,6 +155,7 @@ executables:
 tests:
   spec:
     defaults: hspec/hspec@master
+    main: Main
     ghc-options:
     - -threaded
     - -rtsopts

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Prelude
+
+import Test.Hspec.Runner
+import qualified Spec
+import qualified GHC.IO.Encoding
+
+main :: IO ()
+main = do
+  GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
+  hspecWith defaultConfig Spec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}


### PR DESCRIPTION
This was a problem on some systems as we figured in https://github.com/spacchetti/spago/pull/475#issuecomment-549608062

cc @Benjmhart 