### PR TITLE
Resolve Dhall imports relative to spago.dhall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Bugfixes:
 - Do not watch files in `.spago` folder when running `spago build --watch` (#430)
 - Fix dynamic libraries compatibility problems by publishing a statically linked executable for Linux (#427, #437)
 - `--clear-screen` (usable e.g. with `spago build --watch`) now also resets cursor position, so the rebuild message always appears at top left of the screen (#465)
+- Fix `--config` option when config file is in another directory (#484)
 
 Other improvements:
 - Speed up test suite by replacing couple of end 2 end bump-version tests with unit/property tests

--- a/src/Spago/Dhall.hs
+++ b/src/Spago/Dhall.hs
@@ -20,6 +20,7 @@ import qualified Dhall.Pretty
 import           Dhall.TypeCheck                       (X, typeOf)
 import           Dhall.Util                            as Dhall
 import qualified Lens.Family
+import qualified System.FilePath                       as FilePath
 
 type DhallExpr a = Dhall.Expr Parser.Src a
 
@@ -66,10 +67,10 @@ readImports pathText = do
   let graph = Lens.Family.view Dhall.Import.graph status
   pure $ childImport <$> graph
   where
-    load expr
+    load expr'
       = State.execStateT
-          (Dhall.Import.loadWith expr)
-          (Dhall.Import.emptyStatus ".")
+          (Dhall.Import.loadWith expr')
+          (Dhall.Import.emptyStatus (FilePath.takeDirectory $ Text.unpack pathText))
 
     childImport
       = Dhall.Import.chainedImport . Dhall.Import.child

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -165,6 +165,14 @@ spec = around_ setup $ do
       spago ["-x", "alternative1.dhall", "install", "simple-json"] >>= shouldBeSuccess
       checkFixture "alternative1.dhall"
 
+    it "Spago should install successfully when the config file is in another directory" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+      mkdir "nested"
+      writeTextFile "./nested/spago.dhall" "{ name = \"nested\", sources = [ \"src/**/*.purs\" ], dependencies = [ \"effect\", \"console\", \"psci-support\" ] , packages = ../packages.dhall }"
+      spago ["install", "--config", "./nested/spago.dhall"] >>= shouldBeSuccess
+
     it "Spago should not change the alternative config if it does not change dependencies" $ do
 
       spago ["init"] >>= shouldBeSuccess


### PR DESCRIPTION
### Description of the change

Fixes #478 by making `--config` work properly again for config files in other directories.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
