### PR TITLE
Make global config path absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Bugfixes:
 - Fix dynamic libraries compatibility problems by publishing a statically linked executable for Linux (#427, #437)
 - `--clear-screen` (usable e.g. with `spago build --watch`) now also resets cursor position, so the rebuild message always appears at top left of the screen (#465)
 - Fix `--config` option when config file is in another directory (#484)
+- Make `--config` work correctly with both relative and absolute paths (#485)
 
 Other improvements:
 - Speed up test suite by replacing couple of end 2 end bump-version tests with unit/property tests

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -354,7 +354,9 @@ runWithEnv GlobalOptions{..} app = do
         $ setLogUseColor True
         $ setLogVerboseFormat True
         $ logOptions'
-  let configPath = fromMaybe Config.defaultPath globalConfigPath
+
+  configPath <- fmap Text.pack . makeAbsolute . Text.unpack $ fromMaybe Config.defaultPath globalConfigPath
+
   logDebug'  "Running `getGlobalCacheDir`"
   globalCache <- getGlobalCacheDir
   withLogFunc logOptions $ \logFunc ->

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -217,7 +217,7 @@ runBackend maybeBackend defaultModuleName maybeSuccessMessage failureMessage may
     nodeArgs = Text.intercalate " " $ map Purs.unExtraArg extraArgs
     nodeContents outputPath' =
          let path = fromMaybe "output" outputPath'
-         in "#!/usr/bin/env node\n\n" <> "require('../" <> Text.pack path <> "/" <> Purs.unModuleName moduleName <> "').main()"
+         in "#!/usr/bin/env node\n\n" <> "require('" <> Text.pack path <> "/" <> Purs.unModuleName moduleName <> "').main()"
     nodeCmd = "node .spago/run.js " <> nodeArgs
     nodeAction outputPath' = do
       logDebug "Writing .spago/run.js"

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -152,7 +152,7 @@ ensureConfig = do
   path <- askEnv envConfigPath
   exists <- testfile path
   unless exists $ do
-    die [ display Messages.cannotFindConfig ]
+    die [ display $ Messages.cannotFindConfig path ]
   try parseConfig >>= \case
     Right config -> do
       PackageSet.ensureFrozen $ Text.unpack path
@@ -349,7 +349,7 @@ withConfigAST transform = do
   path <- askEnv envConfigPath
   rawConfig <- liftIO $ Dhall.readRawExpr path
   case rawConfig of
-    Nothing -> die [ display $ Messages.cannotFindConfig ]
+    Nothing -> die [ display $ Messages.cannotFindConfig path ]
     Just (header, expr) -> do
       newExpr <- transformMExpr transform expr
       -- Write the new expression only if it has actually changed

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -112,7 +112,7 @@ parseConfig = do
   withConfigAST $ pure . addSourcePaths
 
   path <- askEnv envConfigPath
-  expr <- liftIO $ Dhall.inputExpr $ "./" <> path
+  expr <- liftIO $ Dhall.inputExpr path
   case expr of
     Dhall.RecordLit ks -> do
       packages :: Map PackageName Package <- Dhall.requireKey ks "packages" (\case

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -47,12 +47,13 @@ failedToParseRepoString repo = makeMessage
   , ""
   ]
 
-cannotFindConfig :: Text
-cannotFindConfig = makeMessage
-  [ "There's no " <> surroundQuote "spago.dhall" <> " in your current location."
+cannotFindConfig :: Text -> Text
+cannotFindConfig path = makeMessage
+  [ "Couldn't find a config file at " <> path
   , ""
   , "If you already have a spago project you might be in the wrong subdirectory,"
-  , "otherwise you might want to run `spago init` to initialize a new project."
+  , "otherwise you might want to run `spago init` to initialize a new project or "
+  , "try the `--config` flag to specify a particular config file"
   ]
 
 cannotFindPackages :: Text

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -1,5 +1,6 @@
 module BumpVersionSpec (spec) where
 
+import qualified Data.Text             as Text
 import           Data.Versions         (SemVer (..), VUnit (..))
 import           Prelude               hiding (FilePath)
 import qualified System.IO.Temp        as Temp
@@ -12,6 +13,7 @@ import           Utils                 (checkFileHasInfix, checkFixture, getHigh
                                         shouldBeFailure, shouldBeFailureInfix, shouldBeSuccess,
                                         spago, withCwd)
 
+import           Spago.Prelude         (makeAbsolute)
 import           Spago.Version         (VersionBump (..), getNextVersion, parseVersion,
                                         parseVersionBump, unparseVersion)
 
@@ -172,5 +174,7 @@ spec = describe "spago bump-version" $ do
         mkdir "purescript-tortellini"
         withCwd "purescript-tortellini" $ spago ["init"] >>= shouldBeSuccess
         setOverrides "{ tortellini = ./purescript-tortellini/spago.dhall as Location }"
+
+        repoPath <- Text.pack <$> makeAbsolute "./purescript-tortellini"
         spago ["bump-version", "minor"] >>= shouldBeFailureInfix
-          "Unable to create Bower version for local repo: ./purescript-tortellini"
+          ("Unable to create Bower version for local repo: " <> repoPath)

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -3,6 +3,7 @@ module SpagoSpec (spec) where
 import           Control.Concurrent (threadDelay)
 import qualified Data.Text          as Text
 import           Prelude            hiding (FilePath)
+import           System.Directory   (makeAbsolute)
 import qualified System.IO.Temp     as Temp
 import           Test.Hspec         (Spec, around_, describe, it, shouldBe, shouldNotSatisfy,
                                      shouldReturn, shouldSatisfy)
@@ -14,7 +15,6 @@ import           Utils              (checkFileHasInfix, checkFixture, readFixtur
                                      shouldBeSuccessStderr, shouldBeFailureStderr,
                                      shouldBeSuccessOutput, shouldBeSuccessOutputWithErr, spago, withCwd,
                                      outputShouldEqual)
-
 
 
 setup :: IO () -> IO ()
@@ -173,6 +173,15 @@ spec = around_ setup $ do
       mkdir "nested"
       writeTextFile "./nested/spago.dhall" "{ name = \"nested\", sources = [ \"src/**/*.purs\" ], dependencies = [ \"effect\", \"console\", \"psci-support\" ] , packages = ../packages.dhall }"
       spago ["install", "--config", "./nested/spago.dhall"] >>= shouldBeSuccess
+
+    it "Spago should install successfully when the config file provided via an absolute path" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+      mkdir "nested"
+      writeTextFile "./nested/spago.dhall" "{ name = \"nested\", sources = [ \"src/**/*.purs\" ], dependencies = [ \"effect\", \"console\", \"psci-support\" ] , packages = ../packages.dhall }"
+      absolutePath <- Text.pack <$> makeAbsolute "./nested/spago.dhall"
+      spago ["install", "--config", absolutePath] >>= shouldBeSuccess
 
     it "Spago should not change the alternative config if it does not change dependencies" $ do
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -598,18 +598,20 @@ spec = around_ setup $ do
       cd "monorepo-1"
       spago ["init"] >>= shouldBeSuccess
 
+      absoluteOutputPath <- Text.pack <$> makeAbsolute "./output"
+
        -- Create local 'monorepo-2' package that uses packages.dhall on top level
       mkdir "monorepo-2"
       cd "monorepo-2"
       spago ["init"] >>= shouldBeSuccess
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
-      spago ["path", "output"] >>= outputShouldEqual "./../output\n"
-      pure ()
+      spago ["path", "output"] >>= outputShouldEqual (absoluteOutputPath <> "\n")
 
     it "Spago should output the local path when no overrides" $ do
 
       mkdir "monorepo-1"
       cd "monorepo-1"
       spago ["init"] >>= shouldBeSuccess
-      spago ["path", "output", "--no-share-output"] >>= outputShouldEqual "output\n"
+      absoluteOutputPath <- Text.pack <$> makeAbsolute "./output"
+      spago ["path", "output", "--no-share-output"] >>= outputShouldEqual (absoluteOutputPath <> "\n")

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -546,7 +546,11 @@ spec = around_ setup $ do
 
       spago ["init"] >>= shouldBeSuccess
       spago ["--no-psa", "build"] >>= shouldBeSuccess
-      spago ["-v", "--no-psa", "run"] >>= shouldBeSuccessOutputWithErr "run-output.txt" "run-no-psa-stderr.txt"
+
+      stdoutText <- readFixture "run-output.txt"
+      outputPath <- makeAbsolute "output"
+      stderrText <- Text.replace "$OUTPUT_PATH" (Text.pack outputPath) <$> readFixture "run-no-psa-stderr.txt"
+      spago ["-v", "--no-psa", "run"] >>= successOutputAndErrShouldEqual stdoutText stderrText
 
   describe "spago bundle" $ do
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -5,6 +5,7 @@ module Utils
   , getHighestTag
   , git
   , outputShouldEqual
+  , successOutputAndErrShouldEqual
   , rmtree
   , runFor
   , shouldBeFailure
@@ -80,6 +81,12 @@ shouldBeSuccessOutputWithErr expected expectedErr (code, stdout, stderr) = do
   code `shouldBe` ExitSuccess
   stdout `shouldBe` expectedStdout
   stderr `shouldBe` expectedStderr
+
+successOutputAndErrShouldEqual :: HasCallStack => Text -> Text -> (ExitCode, Text, Text) -> IO ()
+successOutputAndErrShouldEqual expected expectedErr (code, stdout, stderr) = do
+  code `shouldBe` ExitSuccess
+  stdout `shouldBe` expected
+  stderr `shouldBe` expectedErr
 
 shouldBeSuccessInfix :: HasCallStack => Text -> (ExitCode, Text, Text) -> IO ()
 shouldBeSuccessInfix expected (code, stdout, _stderr) = do

--- a/test/fixtures/run-no-psa-stderr.txt
+++ b/test/fixtures/run-no-psa-stderr.txt
@@ -11,7 +11,7 @@ Running `getGlobalCacheDir`
 [34m[info] [0mInstallation complete.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mCompiling with "purs"[0m
-[32m[debug] [0mRunning command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `purs compile --output $OUTPUT_PATH ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
 [34m[info] [0mBuild succeeded.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mWriting .spago/run.js[0m

--- a/test/fixtures/run-psa-not-installed-stderr.txt
+++ b/test/fixtures/run-psa-not-installed-stderr.txt
@@ -12,7 +12,7 @@ Running `getGlobalCacheDir`
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mFailed to run 'psa --version'[0m
 [32m[debug] [0mCompiling with "purs"[0m
-[32m[debug] [0mRunning command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `purs compile --output $OUTPUT_PATH ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
 [34m[info] [0mBuild succeeded.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mWriting .spago/run.js[0m

--- a/test/fixtures/run-stderr.txt
+++ b/test/fixtures/run-stderr.txt
@@ -11,7 +11,7 @@ Running `getGlobalCacheDir`
 [34m[info] [0mInstallation complete.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mCompiling with "psa"[0m
-[32m[debug] [0mRunning command: `psa compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `psa compile --output $OUTPUT_PATH ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
            Src   Lib   All
 [33mWarnings[0m   [32m0[0m     [32m0[0m     [32m0[0m  
 [31mErrors[0m     [32m0[0m     [32m0[0m     [32m0[0m  


### PR DESCRIPTION
### Description of the change

Fix #472 by making the global config path absolute. As a result of this we also need to make the output path absolute in order for `spago test` to continue working; and this in turn means a bunch of the test fixtures needed updating.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] ~Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
