### PR TITLE
Fail when the test module is not found

### DIFF
--- a/test/Spago/Build/ParserSpec.hs
+++ b/test/Spago/Build/ParserSpec.hs
@@ -1,25 +1,26 @@
 module Spago.Build.ParserSpec (spec) where
 
-import Prelude
-import Test.Hspec
-import Text.Megaparsec
-import Test.Hspec.Megaparsec
-import Data.List.NonEmpty
+import           Data.List.NonEmpty
+import           Prelude
+import           Test.Hspec
+import           Test.Hspec.Megaparsec
+import qualified Text.Megaparsec as Parser
 
-import Spago.Build.Parser
+import           Spago.Build.Parser    (PsModule (..), ModuleExportType(..))
+import qualified Spago.Build.Parser    as Parser
 
 spec :: Spec
 spec = do
-  describe "PureScript Module Parser" $ do
-    it "pModule (fail)" $ do
-      let p = parse pModule ""
+  describe "Parser for module declarations" $ do
+    it "should fail on bad inputs" $ do
+      let p = Parser.parse Parser.moduleDeclaration ""
 
       p `shouldFailOn` "module Test.Main () where"
       p `shouldFailOn` "module Test.Main (,) where"
 
-    it "pModule (success)" $ do
-      let p = parse pModule ""
-      
+    it "should succeed" $ do
+      let p = Parser.parse Parser.moduleDeclaration ""
+
       p "module Test where"
         `shouldParse`
           PsModule "Test" Nothing

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -445,6 +445,12 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       spago ["test"] >>= shouldBeSuccessOutputWithErr "test-output-stdout.txt" "test-output-stderr.txt"
 
+    it "Spago should fail nicely when the test module is not found" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      mv "test" "test2"
+      spago ["test"] >>= shouldBeFailureStderr "spago-test-not-found.txt"
+
     it "Spago should test in custom output folder" $ do
 
       spago ["init"] >>= shouldBeSuccess

--- a/test/fixtures/spago-test-not-found.txt
+++ b/test/fixtures/spago-test-not-found.txt
@@ -1,0 +1,1 @@
+[31m[error] [0mModule 'Test.Main' not found! Are you including it in your build?[0m


### PR DESCRIPTION
This is a small followup on #489 and #383:
- small refactoring of the `Build.runBackend` and `Build.test`, mostly because I realized we accidentally hardcoded `Test.Main` in there
- small refactoring of the `Build.Parser` module to make the names more explicit/consistent with the rest of the codebase
- I think we should fail when there are no tests, otherwise I feel people would not know that they are supposed to add a test module.
  So now the user gets a failure with a nice error message:
  ```
  [error] Module 'Test.Main' not found! Are you including it in your build?
  ```
