### PR TITLE
Make `verify-set` work in the presence of either `.dhall` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+New features:
+- Allow `verify-set` to work with either a `spago.dhall` or a `packages.dhall` (#515)
+
 ## [0.13.1] - 2020-01-10
 
 New features:

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -185,6 +185,9 @@ getNewGitHubToken = makeMessage
   , "and then call `spago login` again so Spago can pick it up and save it to cache"
   ]
 
+couldNotVerifySet :: Text
+couldNotVerifySet = "Could not find a valid \"spago.dhall\" or \"packages.dhall\""
+
 verifying :: Show a => a -> Text
 verifying len = "Verifying " <> tshow len <> " packages, this might take a while.."
 

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -350,6 +350,9 @@ verify :: Maybe CacheFlag -> CheckModulesUnique -> Maybe PackageName -> Spago ()
 verify cacheFlag chkModsUniq maybePackage = do
   logDebug "Running `spago verify`"
 
+  -- @TODO Swap the order of these to check for `spago.dhall` first, once
+  -- `ensureConfig` no longer calls `die` internally. See:
+  -- https://github.com/spacchetti/spago/pull/515#pullrequestreview-329632196
   packageSet@PackageSet{..} <- do
     -- Try to read a "packages.dhall" directly
     try (liftIO (Dhall.inputExpr $ "./" <> PackageSet.packagesPath)) >>= \case 
@@ -358,8 +361,7 @@ verify cacheFlag chkModsUniq maybePackage = do
           -- Try to read a "spago.dhall" and find the packages from there
           try Config.ensureConfig >>= \case
             Right (Config{ packageSet = packageSet@PackageSet{..}, ..}) -> pure packageSet
-            Left (_ :: SomeException) -> die []
-            -- die [ display Messages.whatever ]
+            Left (_ :: SomeException) -> die [ display Messages.couldNotVerifySet ]
 
   case maybePackage of
     -- If no package is specified, verify all of them

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -16,7 +16,6 @@ import           Utils              (checkFileHasInfix, checkFixture, outputShou
                                      withCwd)
 
 
-
 setup :: IO () -> IO ()
 setup cmd = do
   Temp.withTempDirectory "test/" "spago-test" $ \temp -> do
@@ -705,3 +704,15 @@ spec = around_ setup $ do
       cd "monorepo-1"
       spago ["init"] >>= shouldBeSuccess
       spago ["path", "output", "--no-share-output"] >>= outputShouldEqual "output\n"
+
+  describe "spago verify-set" $ do
+    it "Spago should fail when there is no spago.dhall or packages.dhall" $ do
+      spago ["init"] >>= shouldBeSuccess
+      rm "spago.dhall"
+      rm "packages.dhall"
+      spago ["verify-set"] >>= shouldBeFailureStderr "verify-set-failure-no-files.txt"
+
+    it "Spago should fail when packages.dhall is malformed" $ do
+      spago ["init"] >>= shouldBeSuccess
+      writeTextFile "packages.dhall" $ "abcdef"
+      spago ["verify-set"] >>= shouldBeFailureStderr "verify-set-failure-bad-packages-dhall.txt"

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -29,7 +29,8 @@ import           System.Directory   (removePathForcibly)
 import qualified System.Process     as Process
 import           Test.Hspec         (HasCallStack, shouldBe, shouldSatisfy)
 import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString, inproc,
-                                     limit, procStrictWithErr, pwd, readTextFile, strict)
+                                     inprocWithErr, limit, procStrictWithErr, pwd, readTextFile,
+                                     strict)
 
 
 withCwd :: FilePath -> IO () -> IO ()

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -29,8 +29,7 @@ import           System.Directory   (removePathForcibly)
 import qualified System.Process     as Process
 import           Test.Hspec         (HasCallStack, shouldBe, shouldSatisfy)
 import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString, inproc,
-                                     inprocWithErr, limit, procStrictWithErr, pwd, readTextFile,
-                                     strict)
+                                     limit, procStrictWithErr, pwd, readTextFile, strict)
 
 
 withCwd :: FilePath -> IO () -> IO ()

--- a/test/fixtures/verify-set-failure-bad-packages-dhall.txt
+++ b/test/fixtures/verify-set-failure-bad-packages-dhall.txt
@@ -1,0 +1,1 @@
+[31m[error] [0mCould not find a valid "spago.dhall" or "packages.dhall"[0m

--- a/test/fixtures/verify-set-failure-no-files.txt
+++ b/test/fixtures/verify-set-failure-no-files.txt
@@ -1,0 +1,5 @@
+[31m[error] [0mThere's no "spago.dhall" in your current location.
+
+If you already have a spago project you might be in the wrong subdirectory,
+otherwise you might want to run `spago init` to initialize a new project.[0m
+[31m[error] [0mCould not find a valid "spago.dhall" or "packages.dhall"[0m

--- a/test/fixtures/verify-set-success.txt
+++ b/test/fixtures/verify-set-success.txt
@@ -1,0 +1,1 @@
+[31m[error] [0mCould not find a valid "spago.dhall" or "packages.dhall"[0m


### PR DESCRIPTION
### Description of the change

Fixes one specific problem highlighted in #393, though not the general case.

@f-f Wanted to check the general approach with you before I tidy it up. The error messages in particular might be a bit odd because functions like `ensureConfig` call `die` internally, but I worry about this spiralling if I start changing all of those...

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
