### PR TITLE
Log backend command on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Log backend build command if used
+
 ## [0.12.1] - 2019-11-17
 
 Bugfixes:

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -112,7 +112,10 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
                   ]
               Purs.compile globs $ pursArgs ++ [ Purs.ExtraArg "--codegen", Purs.ExtraArg "corefn" ]
 
-              shell backend empty >>= \case
+              logDebug $ display $ "Compiling with backend \"" <> backend <> "\""
+              let backendCmd = backend -- In future there will be some arguments here
+              logDebug $ "Running command `" <> display backendCmd <> "`"
+              shell backendCmd empty >>= \case
                 ExitSuccess   -> pure ()
                 ExitFailure n -> die [ "Backend " <> displayShow backend <> " exited with error:" <> repr n ]
         fromMaybe (pure ()) maybePostBuild


### PR DESCRIPTION
### Description of the change

Add logging of the backend used (when present) for the `build` command. I was expecting the `-v` output to show the backend command being run, similarly to the `purs` command

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
