### PR TITLE
Replaced follow-redirects NPM dependency

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -3,12 +3,10 @@
 // The following implementation comes from
 // https://github.com/justinwoo/npm-psc-package-bin-simple/blob/4d4efa6a4e2008c8a0a71f0b189c14c31b88e47b/install.js
 
-const https = require("follow-redirects").https;
+const request = require("request");
 const tar = require("tar");
 const version = "PACKAGE_VERSION";
 const platform = { win32: "windows", darwin: "osx" }[process.platform] || "linux";
+const url = `https://github.com/spacchetti/spago/releases/download/${version}/${platform}.tar.gz`
 
-https.get(
-    `https://github.com/spacchetti/spago/releases/download/${version}/${platform}.tar.gz`,
-    res => res.pipe(tar.x({"C": './'}))
-);
+request.get(url).pipe(tar.x({"C": './'}));

--- a/npm/package.json
+++ b/npm/package.json
@@ -15,7 +15,7 @@
     "spago": "./spago"
   },
   "dependencies": {
-    "follow-redirects": "^1.7.0",
+    "request": "^2.88.0",
     "tar": "^4.4.8"
   },
   "keywords": [


### PR DESCRIPTION
Replaced `follow-redirects` module with `request`.
The latter follows redirects by default and also respects
HTTP(S) proxy environment variables, allowing spago to be
installed behind a proxy.

Fixes #460

### Description of the change

Replaced `follow-redirects` module with `request`.
The latter follows redirects by default and also respects
HTTP(S) proxy environment variables, allowing spago to be
installed behind a proxy.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
