### PR TITLE
Disable output sharing

### DIFF
--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -163,7 +163,8 @@ parser = do
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
-    useSharedOutput = bool ShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "Disabled using a shared output folder in location of root packages.dhall"
+    -- See https://github.com/spacchetti/spago/pull/526 for why this flag is disabled
+    useSharedOutput = bool NoShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "DEPRECATED: Disabled using a shared output folder in location of root packages.dhall"
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly <*> useSharedOutput
 
     -- Note: by default we limit concurrency to 20

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -95,7 +95,7 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
     NoInstall -> pure ()
   sharedOutputArgs <- case shareOutput of
     ShareOutput   -> getBuildArgsForSharedFolder buildOpts
-    NoShareOutput -> pure []
+    NoShareOutput -> pure pursArgs
   let allPsGlobs = Packages.getGlobs   deps depsOnly configSourcePaths <> sourcePaths
       allJsGlobs = Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -340,7 +340,7 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../../packages.dhall"
       spago ["build"] >>= shouldBeSuccess
-      testdir "output" `shouldReturn` False
+      testdir "output" `shouldReturn` True
 
       cd ".."
       testdir "output" `shouldReturn` True
@@ -380,11 +380,11 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
 
       -- don't use nested folder
-      testdir "output" `shouldReturn` False
+      testdir "output" `shouldReturn` True
 
       -- use middle one
       cd ".."
-      testdir "output" `shouldReturn` True
+      testdir "output" `shouldReturn` False
 
       -- not the trick root folder
       cd ".."
@@ -407,10 +407,10 @@ spec = around_ setup $ do
       rm "spago.dhall"
       writeTextFile "spago.dhall" $ "{ name = \"lib-1\", license = \"MIT\", repository = \"https://github.com/fake/lib-1.git\", dependencies = [\"console\", \"effect\", \"prelude\"], sources = [\"src/**/*.purs\"], packages = ./packages.dhall }"
       spago ["build"] >>= shouldBeSuccess
-      testdir "output" `shouldReturn` False
+      testdir "output" `shouldReturn` True
 
       cd ".."
-      testdir "output" `shouldReturn` True
+      testdir "output" `shouldReturn` False
 
     describe "alternate backend" $ do
 
@@ -474,10 +474,10 @@ spec = around_ setup $ do
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
       spago ["test"] >>= shouldBeSuccess
-      testdir "output" `shouldReturn` False
+      testdir "output" `shouldReturn` True
 
       cd ".."
-      testdir "output" `shouldReturn` True
+      testdir "output" `shouldReturn` False
 
     it "Spago should test successfully with --no-share-output" $ do
 
@@ -609,7 +609,7 @@ spec = around_ setup $ do
       spago ["init"] >>= shouldBeSuccess
       rm "packages.dhall"
       writeTextFile "packages.dhall" $ "../packages.dhall"
-      spago ["path", "output"] >>= outputShouldEqual "./../output\n"
+      spago ["path", "output"] >>= outputShouldEqual "output\n"
       pure ()
 
     it "Spago should output the local path when no overrides" $ do

--- a/test/fixtures/run-no-psa-stderr.txt
+++ b/test/fixtures/run-no-psa-stderr.txt
@@ -9,9 +9,8 @@ Running `getGlobalCacheDir`
 [32m[debug] [0mRunning `fetchPackages`[0m
 [32m[debug] [0mChecking if `purs` is up to date[0m
 [34m[info] [0mInstallation complete.[0m
-[32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mCompiling with "purs"[0m
-[32m[debug] [0mRunning command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
 [34m[info] [0mBuild succeeded.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mWriting .spago/run.js[0m

--- a/test/fixtures/run-psa-not-installed-stderr.txt
+++ b/test/fixtures/run-psa-not-installed-stderr.txt
@@ -9,10 +9,9 @@ Running `getGlobalCacheDir`
 [32m[debug] [0mRunning `fetchPackages`[0m
 [32m[debug] [0mChecking if `purs` is up to date[0m
 [34m[info] [0mInstallation complete.[0m
-[32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mFailed to run 'psa --version'[0m
 [32m[debug] [0mCompiling with "purs"[0m
-[32m[debug] [0mRunning command: `purs compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `purs compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
 [34m[info] [0mBuild succeeded.[0m
 [32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mWriting .spago/run.js[0m

--- a/test/fixtures/run-stderr.txt
+++ b/test/fixtures/run-stderr.txt
@@ -9,9 +9,8 @@ Running `getGlobalCacheDir`
 [32m[debug] [0mRunning `fetchPackages`[0m
 [32m[debug] [0mChecking if `purs` is up to date[0m
 [34m[info] [0mInstallation complete.[0m
-[32m[debug] [0mLocating root path of packages.dhall[0m
 [32m[debug] [0mCompiling with "psa"[0m
-[32m[debug] [0mRunning command: `psa compile --output ./output ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
+[32m[debug] [0mRunning command: `psa compile  ".spago/console/v4.2.0/src/**/*.purs" ".spago/effect/v2.0.1/src/**/*.purs" ".spago/prelude/v4.1.1/src/**/*.purs" ".spago/psci-support/v4.0.0/src/**/*.purs" "src/**/*.purs" "test/**/*.purs"`[0m
            Src   Lib   All
 [33mWarnings[0m   [32m0[0m     [32m0[0m     [32m0[0m  
 [31mErrors[0m     [32m0[0m     [32m0[0m     [32m0[0m  


### PR DESCRIPTION
This PR disables output sharing that was introduced in #422. 

The reasoning for this is twofold:
1. this change seems to break `psc-ide` and various other tooling
2. Spago messing with people's `output` folder doesn't really feel right, because e.g. it forces people to depend on wherever Spago decides the output folder to be in their project

We could of course just invert the logic of the flag and make it opt-in instead, but I just don't think we should encourage the behaviour from point (2) above.

The "proper" way to do this IMHO is that Spago could do some kind of "build artifact caching": i.e. sharing compiled JS between projects compiled with the same set of packages and compiler. This is a strictly better solution, because:
- it doesn't mess with people's output folder
- it enables artifact sharing even between different projects and not just in the same monorepo
