### PR TITLE
Add support for `--before`, `--then` and `--else` flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+New features:
+- Added `--before`, `--then` and `--else` flags to specify commands to run before and after a build.
+
 ## [0.13.0] - 2019-12-19
 
 Breaking changes (😱!!!):

--- a/README.md
+++ b/README.md
@@ -303,6 +303,25 @@ $ spago build --watch
 $ spago build --watch --clear-screen
 ```
 
+To run a command before a build you can use the `--before` flag, eg to clear the screen before a build:
+
+```bash
+$ spago build --watch --before clear
+```
+
+To run a command after the build, use `--then` for successful builds, or `--else` for unsuccessful builds:
+
+```bash
+$ spago build --watch --then "notify-send 'Built successfully'" --else "notify-send 'Build failed'"
+```
+
+Multiple commands are possible - they will be run in the order specified:
+
+```bash
+$ spago build --watch --before clear --before "notify-send 'Building'"
+```
+
+
 If you want to run the program (akin to `pulp run`), just use `run`:
 ```bash
 # The main module defaults to "Main"

--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ $ spago build --watch
 $ spago build --watch --clear-screen
 ```
 
-To run a command before a build you can use the `--before` flag, eg to clear the screen before a build:
+To run a command before a build you can use the `--before` flag, eg to post a notification that a build has started:
 
 ```bash
-$ spago build --watch --before clear
+$ spago build --watch --before "notify-send 'Building'"
 ```
 
 To run a command after the build, use `--then` for successful builds, or `--else` for unsuccessful builds:

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -125,6 +125,10 @@ parser = do
             "update" -> Just NewCache
             _ -> Nothing
       in CLI.optional $ CLI.opt wrap "global-cache" 'c' "Configure the global caching behaviour: skip it with `skip` or force update with `update`"
+
+    beforeCommands = many $ CLI.opt Just "before" 'b' "Commands to run before a build."
+    thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successfull build."
+    elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessfull build."
     packagesFilter =
       let wrap = \case
             "direct"     -> Just DirectDeps
@@ -165,7 +169,9 @@ parser = do
     pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
     -- See https://github.com/spacchetti/spago/pull/526 for why this flag is disabled
     useSharedOutput = bool NoShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "DEPRECATED: Disabled using a shared output folder in location of root packages.dhall"
-    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall <*> pursArgs <*> depsOnly <*> useSharedOutput
+    buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall
+                    <*> pursArgs <*> depsOnly <*> useSharedOutput
+                    <*> beforeCommands <*> thenCommands <*> elseCommands
 
     -- Note: by default we limit concurrency to 20
     globalOptions = GlobalOptions <$> verbose <*> veryVerbose <*> usePsa <*> jobsLimit <*> configPath

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -125,8 +125,8 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
       buildAction globs = do
         runCommands "Before" beforeCommands
         onException ( buildBackend globs ) $ runCommands "Else" elseCommands
-        runCommands "Then" thenCommands
         fromMaybe (pure ()) maybePostBuild
+        runCommands "Then" thenCommands
 
   case shouldWatch of
     BuildOnce -> buildAction allPsGlobs

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -501,6 +501,28 @@ spec = around_ setup $ do
       test <- readTextFile dumpFile
       test `shouldBe` "before1\nbefore2\nthen1\nthen2\n"
 
+    it "Spago should fail the build if a before command fails" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      spago [ "build"
+            , "--before", "exit 1"
+            ] >>= shouldBeFailure
+
+    it "Spago should fail the build if a then command fails" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      spago [ "build"
+            , "--then", "exit 1"
+            ] >>= shouldBeFailure
+
+    it "Spago should still fail the build if an else command fails" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      rm "src/Main.purs"
+      writeTextFile "src/Main.purs" "Invalid Purescript code"
+      spago [ "build"
+            , "--else", "exit 1"
+            ] >>= shouldBeFailure
 
   describe "spago test" $ do
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -441,7 +441,7 @@ spec = around_ setup $ do
 
       dir <- pwd
       let dumpFile = dir </> "testOutput"
-      spago ["build", "--before", "echo before > " <> ( Text.pack $ encodeString dumpFile )] >>= shouldBeSuccess
+      spago ["build", "--before", "echo before>> " <> ( Text.pack $ encodeString dumpFile )] >>= shouldBeSuccess
       test <- readTextFile dumpFile
       test `shouldBe` "before\n"
 
@@ -452,8 +452,8 @@ spec = around_ setup $ do
       dir <- pwd
       let dumpFile = dir </> "testOutput"
       spago [ "build"
-            , "--then", "echo then >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--else", "echo else >> " <> ( Text.pack $ encodeString dumpFile )
+            , "--then", "echo then>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--else", "echo else>> " <> ( Text.pack $ encodeString dumpFile )
             ] >>= shouldBeSuccess
       test <- readTextFile dumpFile
       test `shouldBe` "then\n"
@@ -465,8 +465,8 @@ spec = around_ setup $ do
       dir <- pwd
       let dumpFile = dir </> "testOutput"
       spago [ "build"
-            , "--before", "echo before >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--then", "echo then >> " <> ( Text.pack $ encodeString dumpFile )
+            , "--before", "echo before>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--then", "echo then>> " <> ( Text.pack $ encodeString dumpFile )
             ] >>= shouldBeSuccess
       test <- readTextFile dumpFile
       test `shouldBe` "before\nthen\n"
@@ -480,8 +480,8 @@ spec = around_ setup $ do
       rm "src/Main.purs"
       writeTextFile "src/Main.purs" "Invalid Purescript code"
       spago [ "build"
-            , "--then", "echo then >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--else", "echo else >> " <> ( Text.pack $ encodeString dumpFile )
+            , "--then", "echo then>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--else", "echo else>> " <> ( Text.pack $ encodeString dumpFile )
             ] >>= shouldBeFailure
       test <- readTextFile dumpFile
       test `shouldBe` "else\n"
@@ -493,10 +493,10 @@ spec = around_ setup $ do
       dir <- pwd
       let dumpFile = dir </> "testOutput"
       spago [ "build"
-            , "--before", "echo before1 >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--before", "echo before2 >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--then", "echo then1 >> " <> ( Text.pack $ encodeString dumpFile )
-            , "--then", "echo then2 >> " <> ( Text.pack $ encodeString dumpFile )
+            , "--before", "echo before1>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--before", "echo before2>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--then", "echo then1>> " <> ( Text.pack $ encodeString dumpFile )
+            , "--then", "echo then2>> " <> ( Text.pack $ encodeString dumpFile )
             ] >>= shouldBeSuccess
       test <- readTextFile dumpFile
       test `shouldBe` "before1\nbefore2\nthen1\nthen2\n"


### PR DESCRIPTION
Fix #410

### Description of the change

Added support for commands to be run around the build. `--before` is run before the build, `--then` following a successful build and `--else` following an unsuccessful build.

I realise there were some alternative suggestions in the issue, but I personally prefer the original suggestion as I really liked the way it worked with Pulp.

### Checklist:

- [*] Added the change to the "Unreleased" section of the changelog
- [*] Added some example of the new feature to the `README`
- [*] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
