### PR TITLE
Collapse absolute globs to watch relative paths in source configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ New features:
 - Allow `verify-set` to work with either a `spago.dhall` or a `packages.dhall` (#515)
 - Fix typo on `packages.dhall` template (`let override` should be `let overrides`)
 
+Bugfixes:
+- Fix watching relative paths in sources config (e.g. `../src/**/*.purs`) (#556)
+
 ## [0.13.1] - 2020-01-10
 
 New features:

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -102,7 +102,7 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
   let allPsGlobs = Packages.getGlobs   deps depsOnly configSourcePaths <> sourcePaths
       allJsGlobs = Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths
 
-      buildBackend globs = do 
+      buildBackend globs = do
         case alternateBackend of
           Nothing ->
               Purs.compile globs sharedOutputArgs
@@ -142,7 +142,7 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
       absoluteJSGlobs <- traverse makeAbsolute jsMatches
 
       Watch.watch
-        (Set.fromAscList $ fmap Glob.compile . removeDotSpago $ absolutePSGlobs <> absoluteJSGlobs)
+        (Set.fromAscList $ fmap (Glob.compile . collapse) . removeDotSpago $ absolutePSGlobs <> absoluteJSGlobs)
         shouldClear
         (buildAction (wrap <$> psMatches))
 
@@ -167,6 +167,7 @@ build buildOpts@BuildOptions{..} maybePostBuild = do
     wrap   = Purs.SourcePath . Text.pack
     unwrap = Text.unpack . Purs.unSourcePath
     removeDotSpago = filter (\glob -> ".spago" `notElem` (splitDirectories glob))
+    collapse = Turtle.encodeString . Turtle.collapse . Turtle.decodeString
 
 -- | Start a repl
 repl
@@ -404,14 +405,14 @@ data PathType
 showOutputPath
   :: BuildOptions
   -> Spago ()
-showOutputPath buildOptions = 
+showOutputPath buildOptions =
   outputStr =<< getOutputPathOrDefault buildOptions
 
 showPaths
   :: BuildOptions
   -> Maybe PathType
   -> Spago ()
-showPaths buildOptions whichPaths = 
+showPaths buildOptions whichPaths =
   case whichPaths of
     (Just OutputFolder) -> showOutputPath buildOptions
     Nothing             -> showAllPaths buildOptions
@@ -419,10 +420,10 @@ showPaths buildOptions whichPaths =
 showAllPaths
   :: BuildOptions
   -> Spago ()
-showAllPaths buildOptions = 
+showAllPaths buildOptions =
   traverse_ showPath =<< getAllPaths buildOptions
   where
-    showPath (a,b) 
+    showPath (a,b)
       = output (a <> ": " <> b)
 
 getAllPaths


### PR DESCRIPTION
### Description of the change

I often have a setup like this
```
├── examples
└── src
```
in `examples/spago.dhall`, I have

```
, sources =
    [ "src/**/*.purs", "../src/**/*.purs" ]
```

The problem is file changes in the root src folder won't trigger rebuild, because `/home/rnons/pkg/src/a/b.purs` doesn't match `/home/rnons/pkg/examples/../src/**/*.purs`.

This PR collapses `/home/rnons/pkg/examples/../src/**/*.purs` to `/home/rnons/pkg/src/**/*.purs`, so that watching works as expected.



### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
