### PR TITLE
Create `.purs-repl` template when running `spago init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 New features:
 - Allow `verify-set` to work with either a `spago.dhall` or a `packages.dhall` (#515)
 - Fix typo on `packages.dhall` template (`let override` should be `let overrides`)
+- Create `.purs-repl` file when running `spago init` (#555)
 
 Bugfixes:
 - Fix watching relative paths in sources config (e.g. `../src/**/*.purs`) (#556)

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -68,6 +68,8 @@ initProject force comments = do
 
   copyIfNotExists ".gitignore" Templates.gitignore
 
+  copyIfNotExists ".purs-repl" Templates.pursRepl
+
   logInfo "Set up a local Spago project."
   logInfo "Try running `spago build`"
 
@@ -355,7 +357,7 @@ verify cacheFlag chkModsUniq maybePackage = do
   -- https://github.com/spacchetti/spago/pull/515#pullrequestreview-329632196
   packageSet@PackageSet{..} <- do
     -- Try to read a "packages.dhall" directly
-    try (liftIO (Dhall.inputExpr $ "./" <> PackageSet.packagesPath)) >>= \case 
+    try (liftIO (Dhall.inputExpr $ "./" <> PackageSet.packagesPath)) >>= \case
       Right (Dhall.RecordLit ks) -> Config.parsePackageSet ks
       (_ :: Either SomeException (Dhall.DhallExpr Void))  -> do
           -- Try to read a "spago.dhall" and find the packages from there

--- a/src/Spago/Templates.hs
+++ b/src/Spago/Templates.hs
@@ -27,6 +27,9 @@ gitignore = $(embedFileUtf8 "templates/gitignore")
 bowerJson :: B.ByteString
 bowerJson = $(embedFile "templates/bower.json")
 
+pursRepl :: T.Text
+pursRepl = $(embedFileUtf8 "templates/purs-repl")
+
 docsSearchApp :: T.Text
 docsSearchApp =
   $(embedURLWithFallback

--- a/templates/purs-repl
+++ b/templates/purs-repl
@@ -1,0 +1,1 @@
+import Prelude


### PR DESCRIPTION
Fixes #555

### Description of the change

This change creates a `.purs-repl` file with `import Prelude` as its content if it doesn't already exist when running `spago init`.

Regarding the checklist below, templating of other hidden files (e.g. `.gitignore`) wasn't mentioned in the `README` nor tested. I was consistent with this file, but I'm willing to add tests or `README` documentation if you think it's necessary.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
