### PR TITLE
Remove mention of shared output folder in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,9 +651,6 @@ in upstream // overrides
 }
 ```
 
-To avoid building the same packages over, a shared `output` folder will be created next to your root `packages.dhall`.
-
-To disable this behaviour, pass `--no-share-output` to `spago build`.
 
 ### `devDependencies`, `testDependencies`, or in general a situation with many configurations
 


### PR DESCRIPTION
Fix #552