### PR TITLE
Replace 'list-packages' command with 'ls packages'

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,17 +372,17 @@ You can get a complete list of the packages your `packages.dhall` imports (toget
 with their versions and URLs) by running:
 
 ```bash
-$ spago list-packages
+$ spago ls packages
 ```
 
-By passing the `--filter` flag you can restrict the list to direct or transitive dependencies:
+By using the `ls deps` command instead you can restrict the list to direct or transitive dependencies:
 
 ```bash
 # Direct dependencies, i.e. only the ones listed in spago.dhall
-$ spago list-packages --filter=direct
+$ spago ls deps
 
 # Transitive dependencies, i.e. all the dependencies of your dependencies
-$ spago list-packages -f transitive
+$ spago ls deps --transitive
 ```
 
 
@@ -419,10 +419,10 @@ let overrides =
       }
 ```
 
-Note that if we `list-packages`, we'll see that it is now included as a local package:
+Note that if we do `spago ls packages`, we'll see that it is now included as a local package:
 
 ```bash
-$ spago list-packages
+$ spago ls packages
 ...
 signal                v10.1.0   Remote "https://github.com/bodil/purescript-signal.git"
 sijidou               v0.1.0    Remote "https://github.com/justinwoo/purescript-sijidou.git"
@@ -1117,7 +1117,7 @@ A library published in this way is [purescript-rave](https://github.com/reactorm
 
 For compliance reasons, you might need to fetch all the `LICENSE` files of your dependencies.
 
-To do this you can exploit the `list-packages` command with its `--filter` flag.
+To do this you can exploit the `ls deps` command.
 
 E.g. if you want to print out all the `LICENSE` files of your direct dependencies:
 
@@ -1125,7 +1125,7 @@ E.g. if you want to print out all the `LICENSE` files of your direct dependencie
 #!/usr/bin/env bash
 
 # Note: the `awk` part is to cut out only the package name
-for dep in $(spago list-packages -f direct | awk '{print $1}')
+for dep in $(spago ls deps | awk '{print $1}')
 do
   cat $(find ".spago/${dep}" -iname 'LICENSE')
 done

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -21,7 +21,7 @@ import           Spago.DryRun        (DryRun (..))
 import qualified Spago.GitHub
 import           Spago.GlobalCache   (CacheFlag (..), getGlobalCacheDir)
 import           Spago.Messages      as Messages
-import           Spago.Packages      (CheckModulesUnique (..), JsonFlag (..), PackagesFilter (..))
+import           Spago.Packages      (CheckModulesUnique (..), JsonFlag (..), IncludePackages (..))
 import qualified Spago.Packages
 import qualified Spago.Purs          as Purs
 import           Spago.Types
@@ -54,7 +54,10 @@ data Command
   | Build BuildOptions
 
   -- | List available packages
-  | ListPackages (Maybe PackagesFilter) JsonFlag
+  | ListPackages JsonFlag
+
+  -- | List dependencies of the project
+  | ListDeps JsonFlag IncludeTransitive
 
   -- | Verify that a single package is consistent with the Package Set
   | Verify (Maybe CacheFlag) PackageName
@@ -91,6 +94,9 @@ data Command
   -- | Runs `purescript-docs-search search`.
   | Search
 
+  -- | Returns output folder for compiled code
+  | Path (Maybe PathType) BuildOptions
+
   -- | Show version
   | Version
 
@@ -100,8 +106,8 @@ data Command
   -- | Bundle a module into a CommonJS module (replaced by BundleModule)
   | MakeModule
 
-  -- | Returns output folder for compiled code
-  | Path (Maybe PathType) BuildOptions
+  -- | List available packages (deprecated, old version of ListPackages)
+  | ListPackagesOld
 
 
 data GlobalOptions = GlobalOptions
@@ -114,10 +120,18 @@ data GlobalOptions = GlobalOptions
   , globalConfigPath  :: Maybe Text
   }
 
+data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
+
 parser :: CLI.Parser (Command, GlobalOptions)
 parser = do
   opts <- globalOptions
-  command <- projectCommands <|> packageSetCommands <|> publishCommands <|> otherCommands <|> oldCommands
+  command
+    <-  projectCommands
+    <|> packagesCommands
+    <|> packageSetCommands
+    <|> publishCommands
+    <|> otherCommands
+    <|> oldCommands
   pure (command, opts)
   where
     cacheFlag =
@@ -130,12 +144,6 @@ parser = do
     beforeCommands = many $ CLI.opt Just "before" 'b' "Commands to run before a build."
     thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successfull build."
     elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessfull build."
-    packagesFilter =
-      let wrap = \case
-            "direct"     -> Just DirectDeps
-            "transitive" -> Just TransitiveDeps
-            _            -> Nothing
-      in CLI.optional $ CLI.opt wrap "filter" 'f' "Filter packages: direct deps with `direct`, transitive ones with `transitive`"
     versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     force       = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
@@ -158,6 +166,7 @@ parser = do
     noComments  = bool WithComments NoComments <$> CLI.switch "no-comments" 'C' "Generate package.dhall and spago.dhall files without tutorial comments"
     configPath  = CLI.optional $ CLI.optText "config" 'x' "Optional config path to be used instead of the default spago.dhall"
     chkModsUniq = bool DoCheckModulesUnique NoCheckModulesUnique <$> CLI.switch "no-check-modules-unique" 'M' "Skip checking whether modules names are unique across all packages."
+    transitive  = bool NoIncludeTransitive IncludeTransitive <$> CLI.switch "transitive" 't' "Include transitive dependencies"
 
     mainModule  = CLI.optional $ CLI.opt (Just . ModuleName) "main" 'm' "Module to be used as the application's entry point"
     toTarget    = CLI.optional $ CLI.opt (Just . TargetPath) "to" 't' "The target file path"
@@ -167,11 +176,11 @@ parser = do
     replPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'D' "Package name to add to the REPL as dependency"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include"
 
-    packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `list-packages`"
+    packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `ls packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
     pursArgs        = many $ CLI.opt (Just . ExtraArg) "purs-args" 'u' "Argument to pass to purs"
     -- See https://github.com/spacchetti/spago/pull/526 for why this flag is disabled
-    useSharedOutput = bool NoShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "DEPRECATED: Disabled using a shared output folder in location of root packages.dhall"
+    useSharedOutput = bool NoShareOutput NoShareOutput <$> CLI.switch "no-share-output" 'S' "DEPRECATED: Disable using a shared output folder in location of root packages.dhall"
     buildOptions  = BuildOptions <$> cacheFlag <*> watch <*> clearScreen <*> sourcePaths <*> noInstall
                     <*> pursArgs <*> depsOnly <*> useSharedOutput
                     <*> beforeCommands <*> thenCommands <*> elseCommands
@@ -180,18 +189,6 @@ parser = do
     globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> usePsa
                     <*> jobsLimit <*> configPath
 
-    projectCommands = CLI.subcommandGroup "Project commands:"
-      [ initProject
-      , build
-      , repl
-      , test
-      , run
-      , bundleApp
-      , bundleModule
-      , docs
-      , search
-      , path
-      ]
 
     initProject =
       ( "init"
@@ -258,15 +255,19 @@ parser = do
       , pathSubcommand
       )
 
-    packageSetCommands = CLI.subcommandGroup "Package set commands:"
-      [ install
-      , sources
-      , listPackages
-      , verify
-      , verifySet
-      , upgradeSet
-      , freeze
-      ]
+    listPackages
+      = CLI.subcommand "packages" "List packages available in the local package set"
+        (ListPackages <$> jsonFlag)
+
+    listDeps
+      = CLI.subcommand "deps" "List dependencies of the project"
+        (ListDeps <$> jsonFlag <*> transitive)
+
+    list =
+      ( "ls"
+      , "List command. Supports: `packages`, `deps`"
+      , listPackages <|> listDeps
+      )
 
     install =
       ( "install"
@@ -278,12 +279,6 @@ parser = do
       ( "sources"
       , "List all the source paths (globs) for the dependencies of the project"
       , pure Sources
-      )
-
-    listPackages =
-      ( "list-packages"
-      , "List packages available in your packages.dhall"
-      , ListPackages <$> packagesFilter <*> jsonFlag
       )
 
     verify =
@@ -310,12 +305,6 @@ parser = do
       , pure Freeze
       )
 
-
-    publishCommands = CLI.subcommandGroup "Publish commands:"
-      [ login
-      , bumpVersion
-      ]
-
     login =
       ( "login"
       , "Save the GitHub token to the global cache - set it with the SPAGO_GITHUB_TOKEN env variable"
@@ -338,14 +327,45 @@ parser = do
       , pure Version
       )
 
-
-    oldCommands = Opts.subparser $ Opts.internal <> bundle <> makeModule
+    packagesFilter = CLI.optional $ CLI.opt (const Nothing) "filter" 'f' "Filter packages: direct deps with `direct`, transitive ones with `transitive`"
+    listPackagesOld =
+      Opts.command "list-packages" $ Opts.info (ListPackagesOld <$ packagesFilter <* jsonFlag) mempty
 
     bundle =
       Opts.command "bundle" $ Opts.info (Bundle <$ mainModule <* toTarget <* noBuild <* buildOptions) mempty
 
     makeModule =
       Opts.command "make-module" $ Opts.info (MakeModule <$ mainModule <* toTarget <* noBuild <* buildOptions) mempty
+
+
+    projectCommands = CLI.subcommandGroup "Project commands:"
+      [ initProject
+      , build
+      , repl
+      , test
+      , run
+      , bundleApp
+      , bundleModule
+      , docs
+      , search
+      , path
+      , sources
+      ]
+    packagesCommands = CLI.subcommandGroup "Packages commands:"
+      [ install
+      , list
+      ]
+    packageSetCommands = CLI.subcommandGroup "Package set commands:"
+      [ verify
+      , verifySet
+      , upgradeSet
+      , freeze
+      ]
+    publishCommands = CLI.subcommandGroup "Publish commands:"
+      [ login
+      , bumpVersion
+      ]
+    oldCommands = Opts.subparser $ Opts.internal <> bundle <> makeModule <> listPackagesOld
 
 
 -- | Print out Spago version
@@ -359,32 +379,32 @@ runWithEnv :: GlobalOptions -> Spago a -> IO a
 runWithEnv GlobalOptions{..} app = do
   let verbose = not globalQuiet && (globalVerbose || globalVeryVerbose)
   let logHandle = stderr
-  let logDebug' str = when verbose $ hPutStrLn logHandle str
   logOptions' <- logOptionsHandle logHandle verbose
   let logOptions
         = setLogUseTime globalVeryVerbose
         $ setLogUseLoc globalVeryVerbose
         $ setLogUseColor globalUseColor
-        $ setLogVerboseFormat True
-        $ logOptions'
-  let configPath = fromMaybe Config.defaultPath globalConfigPath
-  logDebug' "Running `getGlobalCacheDir`"
-  globalCache <- getGlobalCacheDir
-  withLogFunc logOptions $ \logFunc ->
-    let
-      logFunc' :: LogFunc
-      logFunc' = if globalQuiet
-        then mkLogFunc $ \_ _ _ _ -> pure ()
-        else logFunc
+        $ setLogVerboseFormat True logOptions'
+  withLogFunc logOptions $ \logFunc -> do
+    let logFunc' :: LogFunc
+        logFunc' = if globalQuiet
+          then mkLogFunc $ \_ _ _ _ -> pure ()
+          else logFunc
 
-      env = Env
-        { envLogFunc = logFunc'
-        , envUsePsa = globalUsePsa
-        , envJobs = fromMaybe 20 globalJobs
-        , envConfigPath = configPath
-        , envGlobalCache = globalCache
-        }
-    in runRIO env app
+    let configPath = fromMaybe Config.defaultPath globalConfigPath
+
+    globalCache <- runRIO logFunc' $ do
+      logDebug "Running `getGlobalCacheDir`"
+      getGlobalCacheDir
+
+    let env = Env
+          { envLogFunc = logFunc'
+          , envUsePsa = globalUsePsa
+          , envJobs = fromMaybe 20 globalJobs
+          , envConfigPath = configPath
+          , envGlobalCache = globalCache
+          }
+    runRIO env app
 
 main :: IO ()
 main = do
@@ -401,7 +421,9 @@ main = do
     case command of
       Init force noComments                 -> Spago.Packages.initProject force noComments
       Install cacheConfig packageNames      -> Spago.Packages.install cacheConfig packageNames
-      ListPackages packagesFilter jsonFlag  -> Spago.Packages.listPackages packagesFilter jsonFlag
+      ListPackages jsonFlag                 -> Spago.Packages.listPackages PackageSetPackages jsonFlag
+      ListDeps jsonFlag IncludeTransitive   -> Spago.Packages.listPackages TransitiveDeps jsonFlag
+      ListDeps jsonFlag NoIncludeTransitive -> Spago.Packages.listPackages DirectDeps jsonFlag
       Sources                               -> Spago.Packages.sources
       Verify cacheConfig package            -> Spago.Packages.verify cacheConfig NoCheckModulesUnique (Just package)
       VerifySet cacheConfig chkModsUniq     -> Spago.Packages.verify cacheConfig chkModsUniq Nothing
@@ -425,3 +447,4 @@ main = do
       Path whichPath buildOptions           -> Spago.Build.showPaths buildOptions whichPath
       Bundle                                -> die [ display Messages.bundleCommandRenamed ]
       MakeModule                            -> die [ display Messages.makeModuleCommandRenamed ]
+      ListPackagesOld                       -> die [ display Messages.listPackagesCommandRenamed ]

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -199,6 +199,10 @@ makeModuleCommandRenamed :: Text
 makeModuleCommandRenamed =
   "The `make-module` command has been replaced with `bundle-module`, so use that instead."
 
+listPackagesCommandRenamed :: Text
+listPackagesCommandRenamed =
+  "The `list-packages` command has been replaced with `ls packages`, so use that instead."
+
 globsDoNotMatchWhenWatching :: NonEmpty Text -> Text
 globsDoNotMatchWhenWatching patterns = makeMessage $
   "WARNING: No matches found when trying to watch the following directories: " : NonEmpty.toList patterns

--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -11,7 +11,7 @@ module Spago.Packages
   , PackageSet.upgradePackageSet
   , PackageSet.freeze
   , PackageSet.packagesPath
-  , PackagesFilter(..)
+  , IncludePackages(..)
   , CheckModulesUnique(..)
   , JsonFlag(..)
   , DepsOnly(..)
@@ -252,7 +252,7 @@ stripPurescriptPrefix (PackageName name) =
   PackageName <$> Text.stripPrefix "purescript-" name
 
 
-data PackagesFilter = TransitiveDeps | DirectDeps
+data IncludePackages = PackageSetPackages | TransitiveDeps | DirectDeps
 
 data JsonFlag = JsonOutputNo | JsonOutputYes
 
@@ -272,14 +272,14 @@ encodeJsonPackageOutput :: JsonPackageOutput -> Text
 encodeJsonPackageOutput = LT.toStrict . LT.decodeUtf8 . Aeson.encode
 
 -- | A list of the packages that can be added to this project
-listPackages :: Maybe PackagesFilter -> JsonFlag -> Spago ()
+listPackages :: IncludePackages -> JsonFlag -> Spago ()
 listPackages packagesFilter jsonFlag = do
   logDebug "Running `listPackages`"
   Config{packageSet = packageSet@PackageSet{..}, ..} <- Config.ensureConfigUnsafe
   packagesToList :: [(PackageName, Package)] <- case packagesFilter of
-    Nothing             -> pure $ Map.toList packagesDB
-    Just TransitiveDeps -> getTransitiveDeps packageSet dependencies
-    Just DirectDeps     -> pure $ Map.toList
+    PackageSetPackages -> pure $ Map.toList packagesDB
+    TransitiveDeps     -> getTransitiveDeps packageSet dependencies
+    DirectDeps         -> pure $ Map.toList
       $ Map.restrictKeys packagesDB (Set.fromList dependencies)
 
   case packagesToList of

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -34,7 +34,7 @@ data PackageLocation
   deriving (Eq, Show, Generic)
 
 
--- | This instance is to make `spago list-packages --json` work
+-- | This instance is to make `spago ls packages --json` work
 instance ToJSON PackageLocation where
   toJSON Remote{..} = object
     [ "tag" .= ("Remote" :: Text)

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -665,21 +665,21 @@ spec = around_ setup $ do
       spago ["bundle-module", "--to", "bundle-module.js", "--no-build"] >>= shouldBeSuccess
       checkFixture "bundle-module.js"
 
-  describe "spago list-packages" $ do
+  describe "spago ls packages" $ do
 
-    it "Spago should list-packages successfully" $ do
-
-      spago ["init"] >>= shouldBeSuccess
-      mv "packages.dhall" "packages-old.dhall"
-      writeTextFile "packages.dhall" "https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4"
-      spago ["list-packages"] >>= shouldBeSuccessOutput "list-packages.txt"
-
-    it "Spago should list-packages in JSON successfully" $ do
+    it "Spago should ls packages successfully" $ do
 
       spago ["init"] >>= shouldBeSuccess
       mv "packages.dhall" "packages-old.dhall"
       writeTextFile "packages.dhall" "https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4"
-      spago ["list-packages", "--json"] >>= shouldBeSuccessOutput "list-packages.json"
+      spago ["ls", "packages"] >>= shouldBeSuccessOutput "list-packages.txt"
+
+    it "Spago should ls packages in JSON successfully" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      mv "packages.dhall" "packages-old.dhall"
+      writeTextFile "packages.dhall" "https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4"
+      spago ["ls", "packages", "--json"] >>= shouldBeSuccessOutput "list-packages.json"
 
   describe "spago path output" $ do
     it "Spago should output the correct path" $ do

--- a/test/fixtures/run-no-psa-stderr.txt
+++ b/test/fixtures/run-no-psa-stderr.txt
@@ -1,4 +1,4 @@
-Running `getGlobalCacheDir`
+[32m[debug] [0mRunning `getGlobalCacheDir`[0m
 [32m[debug] [0mTransformed config is the same as the read one, not overwriting it[0m
 [32m[debug] [0mEnsuring that the package set is frozen[0m
 [32m[debug] [0mRunning with backend: nodejs[0m

--- a/test/fixtures/run-psa-not-installed-stderr.txt
+++ b/test/fixtures/run-psa-not-installed-stderr.txt
@@ -1,4 +1,4 @@
-Running `getGlobalCacheDir`
+[32m[debug] [0mRunning `getGlobalCacheDir`[0m
 [32m[debug] [0mTransformed config is the same as the read one, not overwriting it[0m
 [32m[debug] [0mEnsuring that the package set is frozen[0m
 [32m[debug] [0mRunning with backend: nodejs[0m

--- a/test/fixtures/run-stderr.txt
+++ b/test/fixtures/run-stderr.txt
@@ -1,4 +1,4 @@
-Running `getGlobalCacheDir`
+[32m[debug] [0mRunning `getGlobalCacheDir`[0m
 [32m[debug] [0mTransformed config is the same as the read one, not overwriting it[0m
 [32m[debug] [0mEnsuring that the package set is frozen[0m
 [32m[debug] [0mRunning with backend: nodejs[0m


### PR DESCRIPTION
This PR replaces the all-encompassing `list-packages` command with a `spago ls` command, that now includes a series of subcommands. This is happening for future extensibility, i.e. so that we can add any `spago ls $whatever` subcommand in a non-breaking way whenever we'll want to list more things.

How things got renamed:
- `spago list-packages` → `spago ls packages`
- `spago list-packages -f direct` → `spago ls deps`
- `spago list-packages -f transitive` → `spago ls deps -t`

Note: the `list-packages` command is still there to provide a semi-gracious transition path for folks, and will be removed in a future release.